### PR TITLE
Correct permissions for walthamstowlabourwiki.

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -876,6 +876,12 @@ $wgConf->settings = array(
 				'testgroup' => true,
 			),
 		),
+		'+walthamstowlabourwiki' => array(
+			'*' => array(
+				'edit' => false,
+				'createaccount' => false,
+			),
+		),
 	),
 	'wgGroupsRemoveFromSelf' => array(
 		'default' => array(),
@@ -932,24 +938,6 @@ $wgConf->settings = array(
 			'consul' => array(
 				'bot',
 				'bureaucrat',
-			),
-		),
-		'+walthamstowlabourwiki' => array(
-			'*' => array(
-				'edit' => false,
-				'createpage' => false,
-			),
-			'user' => array(
-				'edit' => false,
-				'createpage' => false,
-			),
-			'confirmed' => array(
-				'edit' => true,
-				'createpage' => true,
-			),
-			'sysop' => array(
-				'edit' => true,
-				'createpage' => true,
 			),
 		),
 	),

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -723,6 +723,7 @@ $wgConf->settings = array(
 				'editor',
 			),
 			'editor-approver' => array(
+				'editor-approver',
 				'editor',
 			),
 		),
@@ -896,6 +897,7 @@ $wgConf->settings = array(
 				'edit' => true,
 			),
 			'editor-approver' => array(
+				'edit' => true,
 			),
 		),
 	),

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -717,6 +717,15 @@ $wgConf->settings = array(
 				'consul',
 			),
 		),
+		'+walthamstowlabourwiki' => array(
+			'sysop' => array(
+				'editor-approver',
+				'editor',
+			),
+			'editor-approver' => array(
+				'editor',
+			),
+		),
 	),
 	'+wgGroupPermissions' => array(
 		'default' => array(
@@ -879,7 +888,14 @@ $wgConf->settings = array(
 		'+walthamstowlabourwiki' => array(
 			'*' => array(
 				'edit' => false,
-				'createaccount' => false,
+			),
+			'user' => array(
+				'edit' => false,
+			),
+			'editor' => array(
+				'edit' => true,
+			),
+			'editor-approver' => array(
 			),
 		),
 	),
@@ -938,6 +954,15 @@ $wgConf->settings = array(
 			'consul' => array(
 				'bot',
 				'bureaucrat',
+			),
+		),
+		'+walthamstowlabourwiki' => array(
+			'sysop' => array(
+				'editor-approver',
+				'editor',
+			),
+			'editor-approver' => array(
+				'editor',
 			),
 		),
 	),


### PR DESCRIPTION
Removed redundant items, added 'createaccount' => false, and moved to wgGroupPermissions.