### PR TITLE
add 'exampleuser' permission on testwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -777,6 +777,7 @@ $wgConf->settings = array(
 				'bot',
 				'bureaucrat',
 				'consul',
+				'exampleuser',
 			),
 		),
 		'+walthamstowlabourwiki' => array(
@@ -947,7 +948,10 @@ $wgConf->settings = array(
 				'read' => true,
 				'testgroup' => true,
 			),
-		),
+			'exampleuser' => array(
+				'editmyoptions' => false,
+			),
+		), 
 		'+walthamstowlabourwiki' => array(
 			'*' => array(
 				'edit' => false,
@@ -1018,6 +1022,7 @@ $wgConf->settings = array(
 			'consul' => array(
 				'bot',
 				'bureaucrat',
+				'exampleuser',
 			),
 		),
 		'+walthamstowlabourwiki' => array(


### PR DESCRIPTION
I want to test it out to see if it works, if yes it will be good so that the Example user's password cannot be changed on testwiki.