### PR TITLE
re-enable Geshi for wikis already there + enable for datasciencewiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -406,10 +406,11 @@ $wgConf->settings = array(
 		'allthetropestestwiki' => true,
 		'extloadwiki' => true,
 	),
-	'wmgUseSyntaxHighlight' => array( // SegFaults with HHVM. Disabled. --John
+	'wmgUseSyntaxHighlight' => array( 
 		'default' => false,
-		'allthetropeswiki' => false,
-		'extloadwiki' => false,
+		'allthetropeswiki' => true,
+		'extloadwiki' => true,
+		'datasciencewiki' => true,
 	),
 	'wmgUseTabsCombination' => array(
 		'default' => false,


### PR DESCRIPTION
Per #169 no longer shows segfaults, SPF said the extension can be used again.