### PR TITLE
Adding 3 of 5 extension requests of stellachronicawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -625,6 +625,7 @@ $wgConf->settings = array(
 		'developmentwiki' => true,
 		'whentheycrywiki' => true,
 		'universebuildwiki' => true,
+		'stellachronicawiki' => true,
 	),
 	'wmgUseTimedMediaHandler' => array(
 		'default' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -377,10 +377,6 @@ $wgConf->settings = array(
 	'wmgUseEchoThanks' => array(
 		'default' => true,
 	),
-	'wmgUseEditcount' => array(
-	    'default' => false,
-	    'extloadwiki' => true,
-	),
 	'wmgUseFeaturedFeeds' => array(
 		'default' => false,
 	),
@@ -584,6 +580,7 @@ $wgConf->settings = array(
 		'whufcyouthwiki' => true,
 		'worldofkirbycraftwiki' => true,
 		'newcolumbiawiki' => true,
+		'stellachronicawiki' => true,
 	),
 	'wmgUseSectionHide' => array(
 		'default' => false,
@@ -600,6 +597,7 @@ $wgConf->settings = array(
 		'extloadwiki' => true,
 		'micropediawiki' => true,
 		'stoutofreachwiki' => true,
+		'stellachronicawiki' => true,
 	),
 	'wmgUseSubpageFun' => array(
 		'default' => false,
@@ -719,6 +717,7 @@ $wgConf->settings = array(
 		'vrgowiki' => true,
 		'walthamstowlabourwiki' => true,
 		'webflowwiki' => true,
+		'stellachronicawiki' => true,
 	),
 	'wmgUseVariables' => array(
 		'default' => false,


### PR DESCRIPTION
I can't enable WikiForum or Tabber as they aren't installed (and I don't know how to install it). I haven't configured parsoid for this wiki for the same reason.
It should be handled by @Southparkfan as it includes the SocialProfile extension