### PR TITLE
Add ExtImg & TitleCap settings to jubeat Wiki @ TH

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -968,6 +968,7 @@ $wgConf->settings = array(
 	),
 	'wgEnableImageWhitelist' => array(
 		'default' => false,
+		'jubeatwikithwiki' => true,
 	),
 
 	// Flow
@@ -1146,6 +1147,10 @@ $wgConf->settings = array(
 	'wgAllowDisplayTitle' => array(
 		'default' => true,
 		'nissanecuwiki' => true,
+	),
+	'wgCapitalLinks' => array(
+		'default' => true,
+		'jubeatwikithwiki' => false,
 	),
 
 	// Mobile


### PR DESCRIPTION
- Allow jubeatwikithwiki to have whitelist for external image
- jubeatwikithwiki doesn't want their page's titles to have capitalized first letter so I've set $wgCapitalLinks = false only for this wiki and = true for all other wiki