### PR TITLE
Remove spam blacklist sources from Wikimedia

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -100,19 +100,6 @@ $wgConf->settings = array(
 	'wgAutoConfirmCount' => array(
 		'default' => 10,
 	),
-	'wgSpamBlacklistFiles' => array(
-		'default' => array(
-			"https://meta.wikimedia.org/w/index.php?title=Spam_blacklist&action=raw&sb_ver=1",
-		),
-	),
-	'wgTitleBlacklistSources' => array(
-		'default' => array(
-			array(
-				'type' => 'url',
-				'src' => 'https://meta.wikimedia.org/w/index.php?title=Title_blacklist&action=raw',
-			),
-		),
-	),
 	// BetaFeatures
 	'wgMediaViewerIsInBeta' => array(
 		'default' => false,


### PR DESCRIPTION
They're designed for a completely different project entirely. A world where links to youtube are bad or Google shortened URLs. Welcome to the real world where if people don't uses them, people complain.

Source of many complaints.