### PR TITLE
add bitcoindebateswiki to DP exception per request on IRC

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1367,6 +1367,7 @@ $wgConf->settings = array(
 		'default' => array(
 			'metawiki',
 			'allthetropeswiki',
+			'bitcoindebateswiki',
 			'spiralwiki',
 			'extloadwiki',
 			'loginwiki',


### PR DESCRIPTION
Requested on IRC by founder: 

9:22 AM <go1111111> the wiki 'bitcoindebates' which I maintain is being flagged for inactivity. the wiki is a roughly finished reference which continues to be useful in its current form. How can I keep it from being closed without having to make a bunch of no-op edits?

9:51 AM <•labster> go1111111: We can mark that wiki with an exception to the dormancy policy
10:03 AM <go1111111> labster: that would be awesome