### PR TITLE
change timezone name from cauarinawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2647,6 +2647,7 @@ $wgConf->settings = array(
 		'default' => 'UTC',
 		'alanpediawiki' => 'Asia/Taipei',
 		'carvingwiki' => 'America/Denver',
+		'casuarinawiki' => 'Asia/Shanghai',
 		'catboxwiki' => 'America/Detroit',
 		'doraemonpediawiki' => 'Asia/Taipei',
 		'libertywiki' => 'Asia/Seoul',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2647,7 +2647,6 @@ $wgConf->settings = array(
 		'default' => 'UTC',
 		'alanpediawiki' => 'Asia/Taipei',
 		'carvingwiki' => 'America/Denver',
-		'casuarinawiki' => 'Asia/Beijing',
 		'catboxwiki' => 'America/Detroit',
 		'doraemonpediawiki' => 'Asia/Taipei',
 		'libertywiki' => 'Asia/Seoul',


### PR DESCRIPTION
I think there is no Asia/Beijing and that's from where the wiki is getting an internal error