### PR TITLE
enabling VE in NS for WW -wisdomwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2727,6 +2727,9 @@ $wgConf->settings = array(
 		'+wisdomwikiwiki' => array(
 			NS_LCS => true,
 			NS_MEDI => true,
+			NS_LIBRARY => true,
+			NS_TEACHING => true,
+			NS_BLANK => true,
 		),
 	),
 	// WebChat config


### PR DESCRIPTION
VE for NS teaching and library and blank for wisdomwiki