### PR TITLE
configuration of wisdomsandboxwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1572,10 +1572,11 @@ $wgConf->settings = array(
 			NS_TEACHING_TALK => 'Teaching_talk',
 			NS_BLANK => 'Blank',
 			NS_BLANK_TALK => 'Blank_talk',
-		)
+		),
 		'wisdomsandboxwiki' => array(
 			NS_TEST	=> 'TEST',
 			NS_TEST_TALK => 'TEST_talk',
+		),	
 	),
 	'wgContentNamespaces' => array(
 		'default' => array( NS_MAIN ),

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -85,6 +85,10 @@ define('NS_TEACHING_TALK', 1661);
 define('NS_BLANK', 1662);
 define('NS_BLANK_TALK', 1663);
 
+// wisdomsandboxwiki
+define( 'NS_TEST',1632);
+define( 'NS_TEST_TALK',1633);
+
 // tmewiki
 define( 'NS_CALL_OF_DUTY', 1628 );
 define( 'NS_CALL_OF_DUTY_TALK', 1629 );
@@ -477,6 +481,8 @@ $wgConf->settings = array(
 			'editor' => true,
 			'sysop' => true,
 		),
+		'+wisdomsandboxwiki' => array(
+			'anon'=true,)
 	),
 
 	// Dormancy policy && RC stuff
@@ -498,6 +504,7 @@ $wgConf->settings = array(
 		'default' => false,
 		'extloadwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseAddHTMLMetaAndTitle' => array(
 		'default' => false,
@@ -558,6 +565,7 @@ $wgConf->settings = array(
 		'extloadwiki' => true,
 		'umodwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseCategoryTree' => array(
 		'default' => true,
@@ -570,6 +578,7 @@ $wgConf->settings = array(
 		'extloadwiki' => true,
 		'walthamstowlabourwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseContactPage' => array(
 		'default' => false, // Add wiki config to ContactPage.php
@@ -582,6 +591,7 @@ $wgConf->settings = array(
 		'anuwiki' => true,
 		'extloadwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseComments' => array(
 		'default' => false,
@@ -613,6 +623,7 @@ $wgConf->settings = array(
 		'hydrawikiwiki' => true,
 		'walthamstowlabourwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseEchoThanks' => array(
 		'default' => true,
@@ -654,6 +665,7 @@ $wgConf->settings = array(
 		'universebuildwiki' => true,
 		'walthamstowlabourwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 		'yacresourceswiki' => true,
 		'yggdrasilwiki' => true,
 	),
@@ -750,6 +762,7 @@ $wgConf->settings = array(
 		'webflowwiki' => true,
 		'whentheycrywiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseMultimediaViewer' => array(
 		'default' => false,
@@ -762,6 +775,7 @@ $wgConf->settings = array(
 		'allthetropeswiki' => true,
 		'extloadwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseNativeSvgHandler' => array(
 	    'default' => true,
@@ -777,6 +791,8 @@ $wgConf->settings = array(
 		'developmentwiki' => true,
 		'extloadwiki' => true,
 		'universebuildwiki' => true,
+		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseNoTitle' => array(
 		'default' => false,
@@ -835,6 +851,7 @@ $wgConf->settings = array(
 		'extloadwiki' => true,
 		'idtestwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseScratchBlocks' => array(
 		'default' => false,
@@ -917,6 +934,7 @@ $wgConf->settings = array(
 		'whentheycrywiki' => true,
 		'whufcyouthwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 		'worldbuildingwiki' => true,
 		'worldofkirbycraftwiki' => true,
 	),
@@ -1143,6 +1161,7 @@ $wgConf->settings = array(
 		'wikicervanteswiki' => true,
 		'wikikaisagawiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 		'wikihoyowiki' => true,
 		'worldbuildingwiki' => true,
 		'yourosongcontestwiki' => true,
@@ -1183,6 +1202,7 @@ $wgConf->settings = array(
 		'stellachronicawiki' => true,
 		'wikicervanteswiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseWikiLove' => array(
 		'default' => false,
@@ -1227,6 +1247,7 @@ $wgConf->settings = array(
 		'urho3dwiki' => true,
 		'valentinaprojectwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 		'worldpediawiki' => true,
 		'webflowwiki' => true,
 		'yacresourceswiki' => true,
@@ -1239,6 +1260,7 @@ $wgConf->settings = array(
 		'sylwiki' => '_blank',
 		'vrgowiki' => '_blank',
 		'wisdomwikiwiki' => '_blank',
+		'wisdomsandboxwiki' => '_blank',
 	),
 
 	// Files
@@ -2741,6 +2763,9 @@ $wgConf->settings = array(
 			NS_LIBRARY => true,
 			NS_TEACHING => true,
 			NS_BLANK => true,
+		),
+		'+wisdomwikiwiki' => array(
+			NS_TEST => true,
 		),
 	),
 	// WebChat config

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -482,7 +482,7 @@ $wgConf->settings = array(
 			'sysop' => true,
 		),
 		'+wisdomsandboxwiki' => array(
-			'anon'=true,)
+			'anon' => true,)
 	),
 
 	// Dormancy policy && RC stuff

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -482,7 +482,8 @@ $wgConf->settings = array(
 			'sysop' => true,
 		),
 		'+wisdomsandboxwiki' => array(
-			'anon' => true,)
+			'anon' => true,
+		),
 	),
 
 	// Dormancy policy && RC stuff
@@ -1572,6 +1573,9 @@ $wgConf->settings = array(
 			NS_BLANK => 'Blank',
 			NS_BLANK_TALK => 'Blank_talk',
 		)
+		'wisdomsandboxwiki' => array(
+			NS_TEST	=> 'TEST',
+			NS_TEST_TALK => 'TEST_talk',
 	),
 	'wgContentNamespaces' => array(
 		'default' => array( NS_MAIN ),

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -823,6 +823,7 @@ $wgConf->settings = array(
 		'poserdazfreebieswiki' => true,
 		'priyowiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUsePopups' => array(
 		'default' => false,
@@ -1184,6 +1185,7 @@ $wgConf->settings = array(
 		'allthetropeswiki' => true,
 		'extloadwiki' => true,
 		'wisdomwikiwiki' => true,
+		'wisdomsandboxwiki' => true,
 	),
 	'wmgUseWidgets' => array(
 		'default' => false,
@@ -2472,6 +2474,7 @@ $wgConf->settings = array(
 		'wikikaisagawiki' => 'https://wiki.kaisaga.com',
 		'wikiparkinsonwiki' => 'https://wikiparkinson.org',
 		'wisdomwikiwiki' => 'https://wisdomwiki.org',
+		'wisdomsandboxwiki' => 'https://sandbox.wisdomwiki.org',
 		'zepaltusprojectwiki' => 'https://wiki.zepaltusproject.com',
 	),
 	'wgShowHostnames' => array(
@@ -2781,18 +2784,21 @@ $wgConf->settings = array(
 		'allthetropeswiki' => 'irc.freenode.net',
 		'extloadwiki' => 'irc.freenode.net',
 		'wisdomwikiwiki' => 'irc.freenode.net',
+		'wisdomsandboxwiki' => 'irc.freenode.net',
 	),
 	'wmgWebChatChannel' => array(
 		'default' => false,
 		'allthetropeswiki' => '#miraheze-allthetropes',
 		'extloadwiki' => '#miraheze-staff',
 		'wisdomwikiwiki' => '#miraheze-wisdomwiki',
+		'wisdomsandboxwiki' => '#miraheze-wisdomwiki',
 	),
 	'wmgWebChatClient' => array(
 		'default' => false,
 		'allthetropeswiki' => 'freenodeChat',
 		'extloadwiki' => 'freenodeChat',
 		'wisdomwikiwiki' => 'freenodeChat',
+		'wisdomsandboxwiki' => 'freenodeChat',
 	),
 
 	// Empty arrays (do not touch unless you know what you're doing)

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2576,6 +2576,7 @@ $wgConf->settings = array(
 		'wikibookswiki' => "//$wmgUploadHostname/wikibookswiki/6/60/Wiki_favicon.png",
 		'wikicervanteswiki' => "//$wmgUploadHostname/wikicervanteswiki/0/08/FaviconCervantes.ico",
 		'wisdomwikiwiki' => "//$wmgUploadHostname/wisdomwikiwiki/6/64/Favicon.ico",
+		'wisdomsandboxwiki' => "//$wmgUploadHostname/wisdomsandboxwiki/6/64/Favicon.ico",
 	),
 	'wgLogo' => array(
 		'default' => "//$wmgUploadHostname/metawiki/3/35/Miraheze_Logo.svg",
@@ -2693,6 +2694,7 @@ $wgConf->settings = array(
 		'wikibookswiki' => "//$wmgUploadHostname/wikibookswiki/3/3b/Wiki_logo.png",
 		'wikicervanteswiki' => "//$wmgUploadHostname/wikicervanteswiki/0/0c/LogodelWiki.png",
 		'wisdomwikiwiki' => "//$wmgUploadHostname/wisdomwikiwiki/0/02/WWlogo.png",
+		'wisdomsandboxwiki' => "//$wmgUploadHostname/wisdomsandboxwiki/b/be/Sandbox_Logo.png",
 		'yggdrasilwiki' => "//$wmgUploadHostname/yggdrasilwiki/c/cd/Yggdrasil-logo.png",
 	),
 


### PR DESCRIPTION
~ enabled FLOW and FORUM (needs parsoid enabled and run update.php manually)
~ more or less cloning most of the wisdomwiki-settings
~ all wisdomsandbox stuff is underneath wisdomwiki, for its a sub-wiki, and only appears when WW entry is present (seemed sensemaking). hope thats an acceptable exception of the alphanum-sortrule.
~ doublechecked the 'NS_TEST',1632 and TALK 1633 they are leftovers from an earlier shift and not in use as of now.