### PR TITLE
add protect restriction on testwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2442,6 +2442,9 @@ $wgConf->settings = array(
 		'default' => array(
 			'delete',
 		),
+		'testwiki' => array(
+			'deleterevision',
+		),
 	),
 
 	// Server


### PR DESCRIPTION
As most people have administrator we need an oversight which is only visible by bureaucrats/consuls. I'm not sure this is done correctly.