### PR TITLE
Add $wgNamespacesToBeSearchedDefault to search Tech on metawiki default

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1722,6 +1722,12 @@ $wgConf->settings = array(
 			'画像' => NS_FILE,
 		),
 	),
+	'+wgNamespacesToBeSearchedDefault' => array(
+		'default' => array(),
+		'+metawiki' => array(
+			NS_TECH => true,
+		),
+	),
 	'+wgNamespacesWithSubpages' => array(
 		'default' => array(),
 		'+adnovumwiki' => array(


### PR DESCRIPTION
Hay guys, I thought this might be a good idea.