### PR TITLE
disable InstantCommons for pso2wiki T883

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1625,7 +1625,7 @@ $wgConf->settings = array(
 	'wgUseInstantCommons' => array(
 		'default' => true,
 		'amaninfowiki' => false,
-		'pso2wiki' => true,
+		'pso2wiki' => false,
 		'thefosterswiki' => false,
 	),
 	'wgEnableImageWhitelist' => array(


### PR DESCRIPTION
Was accidentally set as `true` instead of `false`.