### PR TITLE
Disable ManageWiki on metawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2057,7 +2057,6 @@ $wgConf->settings = array(
 	'wgEnableManageWiki' => array(
 		'default' => false,
 		'extloadwiki' => true,
-		'metawiki' => true,
 	),
 	
 	// MassMessage


### PR DESCRIPTION
Really this should be tested on extload before enabling other wikis, which is why we should probably disable it on meta, also there is request that requires access to Special:ManageWiki and when ManageWiki is enabled our acces to it is gone. The special page dissappears.