### PR TITLE
Include tagmanager permissions in the sysop group

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3194,7 +3194,10 @@ $wgConf->settings = array(
 				'supressredirect' => true,
 			),
 			'sysop' => array(
-				'protectsite' => true
+				'protectsite' => true,
+				'changetags' => true,
+				'managechangetags' => true,
+				'applychangetags' => true,
 			),
 			'tagmanager' => array(
 				'changetags' => true,


### PR DESCRIPTION
This way I don't have to grant myself tagmanager rights every time I edit a tag