### PR TITLE
move permission variables to LocalWiki.php

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -501,29 +501,3 @@ if ( $wmgUseWikiTextLoggedInOut ) {
 if ( $wmgUseYouTube ) {
 	require_once( "$IP/extensions/YouTube/YouTube.php" );
 }
-
-// Permission variables
-if ( $wmgEditingMatrix ) {
-	$mhEM = $wmgEditingMatrix;
-	if ( $mhEM['anon'] ) {
-		$wgGroupPermissions['*']['edit'] = false;
-		$wgGroupPermissions['*']['createpage'] = false;
-	}
-
-	if ( $mhEM['user'] ) {
-		$wgGroupPermissions['user']['edit'] = false;
-		$wgGroupPermissions['user']['createpage'] = false;
-	}
-
-	if ( $mhEM['editor'] ) {
-		$wgGroupPermissions['editor']['edit'] = true;
-		$wgGroupPermissions['editor']['createpage'] = true;
-		$wgAddGroups['sysop'][] = 'editor';
-		$wgRemoveGroups['sysop'][] = 'editor';
-	}
-
-	if ( $mhEM['sysop'] ) {
-		$wgGroupPermissions['sysop']['edit'] = true;
-		$wgGroupPermissions['sysop']['createpage'] = true;
-	}
-}

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -228,3 +228,29 @@ $wgWhitelistRead =
 		"Special:UserLogout",
 		"Special:CreateAccount",
 );
+
+// Permission variables
+if ( $wmgEditingMatrix ) {
+	$mhEM = $wmgEditingMatrix;
+	if ( $mhEM['anon'] ) {
+		$wgGroupPermissions['*']['edit'] = false;
+		$wgGroupPermissions['*']['createpage'] = false;
+	}
+
+	if ( $mhEM['user'] ) {
+		$wgGroupPermissions['user']['edit'] = false;
+		$wgGroupPermissions['user']['createpage'] = false;
+	}
+
+	if ( $mhEM['editor'] ) {
+		$wgGroupPermissions['editor']['edit'] = true;
+		$wgGroupPermissions['editor']['createpage'] = true;
+		$wgAddGroups['sysop'][] = 'editor';
+		$wgRemoveGroups['sysop'][] = 'editor';
+	}
+
+	if ( $mhEM['sysop'] ) {
+		$wgGroupPermissions['sysop']['edit'] = true;
+		$wgGroupPermissions['sysop']['createpage'] = true;
+	}
+}


### PR DESCRIPTION
I think that LocalWiki.php is a better place for the permission variables than LocalExtensions.php