### PR TITLE
Unset CU group on Elements Wiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -102,7 +102,7 @@ if ( $wgDBname == 'elementswiki' ) {
 	$wgGroupPermissions['*']['flow-hide'] = false;
 	unset( $wgGroupPermissions['suppress'] );
 	unset( $wgGroupPermissions['rollbacker'] );
-	unset( $wgGroupPermissions['checkuser'];
+	unset( $wgGroupPermissions['checkuser'] );
 	$wgGroupPermissions['sysop']['flow-delete'] = false;
 	$wgGroupPermissions['sysop']['flow-edit-post'] = false;
 	$wgGroupPermissions['sysop']['flow-lock'] = false;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -102,6 +102,7 @@ if ( $wgDBname == 'elementswiki' ) {
 	$wgGroupPermissions['*']['flow-hide'] = false;
 	unset( $wgGroupPermissions['suppress'] );
 	unset( $wgGroupPermissions['rollbacker'] );
+	unset( $wgGroupPermissions['checkuser'];
 	$wgGroupPermissions['sysop']['flow-delete'] = false;
 	$wgGroupPermissions['sysop']['flow-edit-post'] = false;
 	$wgGroupPermissions['sysop']['flow-lock'] = false;


### PR DESCRIPTION
The use of CheckUser locally on Elements Wiki is prohibited per https://elements.miraheze.org/wiki/Elements:Privacy_policy#CheckUser barring exceptional circumstances. If one of those exceptional circumstances should arise, stewards can perform CU globally via Meta anyway.