### PR TITLE
Revert "Enable VisualEditor on tsponiewiki per T1265"

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1859,7 +1859,6 @@ $wgConf->settings = array(
 		'touhouenginewiki' => true,
 		'trexwiki' => true,
 		'trumpwiki' => true,
-		'tsponiewiki' => true,
 		'unikumwiki' => true,
 		'universebuildwiki' => true,
 		'urho3dwiki' => true,


### PR DESCRIPTION
Reverts miraheze/mw-config#1176

Thought parsoid config was done. @DeltaQuad-DQ This is not your fault but please always make a PR for parsoid config too and/or link it here.