### PR TITLE
64 hour autoblocks on brynda1231 per T1318

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -202,6 +202,10 @@ $wgConf->settings = array(
 	),
 
 	// Block
+	'wgAutoblockExpiry' => array(
+		'default' => 86400, // 24 hours * 60 minutes * 60 seconds
+		'brynda1231wiki' => 230400, // 64 hours * 60 minutes * 60 seconds
+	),
 	'wgBlockAllowsUTEdit' => array(
 		'default' => true,
 	),


### PR DESCRIPTION
also set up wgAutoblockExpiry with default at 86400 (24 hours - as it should be)