### PR TITLE
grant editothersprofiles to sysops

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -404,6 +404,7 @@ if ( $wmgUseSiteScout ) {
 
 if ( $wmgUseSocialProfile ) {
 	require_once( "$IP/extensions/SocialProfile/SocialProfile.php" );
+	wgAddGroups['bureaucrat'][] = 'staff';
 }
 
 if ( $wmgUseSubpageFun ) {

--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -404,7 +404,8 @@ if ( $wmgUseSiteScout ) {
 
 if ( $wmgUseSocialProfile ) {
 	require_once( "$IP/extensions/SocialProfile/SocialProfile.php" );
-	wgAddGroups['bureaucrat'][] = 'staff';
+	unset( $wgGroupPermissions['staff'] );
+	$wgGroupPermissions['sysop']['editothersprofiles'] = true;
 }
 
 if ( $wmgUseSubpageFun ) {


### PR DESCRIPTION
~~In it's current configuration, the group can only be added by Stewards. It may be better to just `unset( $wgGroupPermissions['staff'] );` and assign `$wgGroupPermissions['sysop']['editothersprofiles'] = true;`, but this is the least (possibly) controversial of the two actions.~~
See T1397 for reference.