### PR TITLE
Enable VisualEditor for bchwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1816,6 +1816,7 @@ $wgConf->settings = array(
 		'attackontitanwiki' => true,
 		'augustinianumwiki' => true,
 		'aurcusonlinewiki' => true,
+		'bchwiki' => true,
 		'bgowiki' => true,
 		'betapurplewiki' => true,
 		'bettermediawiki' => true,


### PR DESCRIPTION
Rather than log an issue on phabricator - I've found this is what volunteers end up doing, so have simply added code to enable VisualEditor for bchwiki directly.