### PR TITLE
move bigforestwiki to db3

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -4,6 +4,7 @@ $wgLBFactoryConf = array(
 	'class' => 'LBFactoryMulti',
 	'sectionsByDB' => array(
 		'allthetropeswiki' => 'c2',
+		'bigforestwiki' => 'c2',
 		'buswiki' => 'c2',
 		'centralauth' => 'c2',
 		'extloadwiki' => 'c2',


### PR DESCRIPTION
second largest wiki, I think it should be move to db3