### PR TITLE
Removing all permissions from CheckUser group

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -172,6 +172,8 @@ if ( $wgDBname == 'wikicanadawiki' ) {
 	$wgGroupPermissions['user']['move-subpages'] = false;
 	$wgGroupPermissions['user']['move-rootuserpages'] = false;
 	$wgGroupPermissions['user']['movefile'] = false;
+	$wgGroupPermissions['checkuser']['checkuser'] = false;
+	$wgGroupPermissions['checkuser']['checkuser-log'] = false;
 	$wgAddGroups['sysop'] = array();
 	$wgRemoveGroups['sysop'] = array();
 	$wgAddGroups['bureaucrat'] = array();


### PR DESCRIPTION
Since the group cannot be deleted and since checkuser rights have been assigned to the steward group, removing all permissions from the CheckUser group should invalidate it.