### PR TITLE
Disable TorBlock on WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1883,6 +1883,7 @@ $wgConf->settings = array(
 	),
 	'wmgUseTorBlock' => array(
 		'default' => true,
+		'wikicanadawiki' => false,
 	),
 	'wmgUseTranslate' => array(
 		'default' => false,


### PR DESCRIPTION
I don't see a need for it, for a few reasons:

A). There has only been one instance of serious spam. All other attempts have been stopped before they got out of hand
B). I have no evidence that any of the vandals/spammers were connecting through Tor
C). I don't want to be restrictive as to block an entire web provider from accessing my wiki

I will revert this change if I see clear reason to