### PR TITLE
Enable <img> tag on Westmarches

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2406,6 +2406,12 @@ $wgConf->settings = array(
 		'default' => false,
 		'westmarcheswiki' => true,
 	),
+	
+	// Allow HTML <img> tag
+	'wgAllowwgAllowImageTag' => array (
+		'default' => false,
+		'westmarcheswiki' => true,
+	),
 
 	// FlaggedRevs
 	'wmgFlaggedRevsNamespaces' => array(

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2408,7 +2408,7 @@ $wgConf->settings = array(
 	),
 	
 	// Allow HTML <img> tag
-	'wgAllowwgAllowImageTag' => array(
+	'wgAllowImageTag' => array(
 		'default' => false,
 		'westmarcheswiki' => true,
 	),

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2408,7 +2408,7 @@ $wgConf->settings = array(
 	),
 	
 	// Allow HTML <img> tag
-	'wgAllowwgAllowImageTag' => array (
+	'wgAllowwgAllowImageTag' => array(
 		'default' => false,
 		'westmarcheswiki' => true,
 	),


### PR DESCRIPTION
I hope that setting [default = false] is correct. I have tried to verify that it is not being set elsewhere in this file and that false should be the defualt value.

https://www.mediawiki.org/wiki/Manual:%24wgAllowImageTag