### PR TITLE
Define local "sysadmin" group on Meta

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3499,6 +3499,12 @@ $wgConf->settings = array(
 				'commentadmin',
 			),
 		),
+		'+metawiki' => array(
+			'sysadmin' => array(
+				'wikicreator',
+				'sysadmin',
+			),
+		),
 		'+trexwiki' => array(
 			'co' => array(
 				'ceo',
@@ -3965,9 +3971,6 @@ $wgConf->settings = array(
 				'centralauth-oversight' => true,
 				'centralauth-rename' => true,
 				'centralauth-unmerge' => true,
-				'createwiki' => true,
-				'managewiki' => true,
-				'managewiki-restricted' => true,
 				'noratelimit' => true,
 				'userrights' => true,
 				'userrights-interwiki' => true,
@@ -3979,6 +3982,11 @@ $wgConf->settings = array(
 			'wikicreator' => array(
 				'createwiki' => true,
 				'managewiki' => true,
+			),
+			'sysadmin' => array(
+				'createwiki' => true,
+				'managewiki' => true,
+				'managewiki-restricted' => true,
 			),
 		),
 		'+pgnwikiwiki' => array(
@@ -4352,6 +4360,13 @@ $wgConf->settings = array(
 			),
 			'sysop' => array(
 				'commentadmin',
+			),
+		),
+		'+metawiki' => array(
+			'sysadmin' => array(
+				'wikicreator',
+				'sysadmin',
+				'bureaucrat',
 			),
 		),
 		'+quantumwiki' => array(


### PR DESCRIPTION
I'm doing this for a couple of reasons.

A). The wiki creator policy states that "wiki creator rights are granted at the discretion of a sysadmin". However, currently, non-steward sysadmins need to assign "userrights" in the global sysadmin group and then assign local wiki creator rights on Meta. It would be nice if sysadmins could just assign wiki creator directly

B). Technically, the managewiki-restricted right should be sysadmin only, as the top of Special:ManageWiki says "if you cannot change all settings you should contact a system administrator".

C). It would be good if sysadmins could revoke bureaucrat rights on Meta, since we have more sysadmins than stewards currently