### PR TITLE
Disable deletion protection on WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4578,7 +4578,7 @@ $wgConf->settings = array(
 		'default' => array(
 			'delete',
 		),
-		'wikicanadawiki' => array();
+		'wikicanadawiki' => array(
 		),
 	),
 	

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4578,6 +4578,8 @@ $wgConf->settings = array(
 		'default' => array(
 			'delete',
 		),
+		'wikicanadawiki' => array();
+		),
 	),
 	
 	// Robot policy


### PR DESCRIPTION
Pointless, as only sysops can delete pages anyway