### PR TITLE
Fix Error on Protect Levels for "PruebaWiki"

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4705,6 +4705,7 @@ $wgConf->settings = array(
 			'delete',
 		),
 		'pruebawiki' => array(
+			'delete',
 			'protect',
 		),
 		'wikicanadawiki' => array(


### PR DESCRIPTION
I accidentally deleted the "Delete" protection level when I want to add another one. I ask that you add this configuration to the wiki. Thanks.