### PR TITLE
Create local "sysadmin" group on WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3681,6 +3681,7 @@ $wgConf->settings = array(
 				'importer',
 				'uploader',
 				'template-editor',
+				'sysadmin',
 			),
 		),	
 		'+wikidolphinhansenwiki' => array(
@@ -4378,6 +4379,14 @@ $wgConf->settings = array(
 				'proxyunbannable' => true,
 				'torunblocked' => true,
 			),
+			'sysadmin' => array(
+				'read' => true,
+				'edit' => true,
+				'move' => true,
+				'protect' => true,
+				'delete' => true,
+				'undelete' => true,
+			),
 		),	
 		'+wikipucwiki' => array(
 			'*' => array(
@@ -4597,6 +4606,7 @@ $wgConf->settings = array(
 				'importer',
 				'uploader',
 				'template-editor',
+				'sysadmin',
 			),
 		),
 		'+wikidolphinhansenwiki' => array(

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4386,6 +4386,9 @@ $wgConf->settings = array(
 				'protect' => true,
 				'delete' => true,
 				'undelete' => true,
+				'block' => true,
+				'blockemail' => true,
+				'unblockself' => true,
 			),
 		),	
 		'+wikipucwiki' => array(


### PR DESCRIPTION
This is a null group, similar to the Wikimedia Foundation's "OTRS Member" gloabl group. It contains basic administrator and user permissions (nothing advanced) and is used solely to distinguish global Miraheze sysadmins in the WikiCanada user list