### PR TITLE
Prevent global abuse filter 12 from taking actions on WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -203,6 +203,10 @@ $wgConf->settings = array(
 			'degroup' => false,
 			'rangeblock' => true,
 		),
+		'wgAbuseFilterDisallowGlobalLocalBlocks' => array(
+			'default' => false,
+			'wikicanadawiki' => true,
+		),
 	),
 
 	// Anti-spam


### PR DESCRIPTION
I don't like the fact that global abuse filter 12 has blocking and removing groups enabled. IMHO those restricted actions should never be enabled for global filters. As a result, I am preventing said filter from taking those actions on WikiCanada