### PR TITLE
Disable BootstrapMediaWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -960,7 +960,6 @@ $wgConf->settings = array(
 	'wmgUseBootstrapMediawiki' => array(
 		'default' => false,
 		'extloadwiki' => true,
-		'fablabesdswiki' => true,
 		'kstartupswiki' => true,
 	),
 	'wmgUseMSCalendar' => array(


### PR DESCRIPTION
So I was playing around with the theme, created the template Bootstrap:Subnav and then nothing works! It always give me a 500 error and I don't wont to crash the server. Even if I want to go back to the settings page and change my theme to the default one, I can't! :cry: 

Here is the end of the story between my wiki and the skin :stuck_out_tongue_winking_eye: 