### PR TITLE
Remove AbuseFilter degrouping on WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -179,6 +179,7 @@ $wgConf->settings = array(
 			'tag' => true,
 		),
 		'wikicanadawiki' => array(
+			'degroup' => false,
 			'rangeblock' => true,
 		),
 	),


### PR DESCRIPTION
The "Abuse filter" account does not have the technical ability to degroup as editing userrights is restricted to founder and stewards