### PR TITLE
Revert disabling of TorBlock on WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1943,7 +1943,6 @@ $wgConf->settings = array(
 	),
 	'wmgUseTorBlock' => array(
 		'default' => true,
-		'wikicanadawiki' => false,
 	),
 	'wmgUseTranslate' => array(
 		'default' => false,


### PR DESCRIPTION
I tried to go without it in order to reduce collateral chances, but a few days after turning it off there was vandalism again. There was little to no vandalism with it enabled, so if I had to guess, the vandal(s) are relying on Tor.