### PR TITLE
remove metawiki from c1 define

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -8,7 +8,6 @@ $wgLBFactoryConf = array(
 		'centralauth' => 'c2',
 		'extloadwiki' => 'c2',
 		'loginwiki' => 'c2',
-		'metawiki' => 'c1',
 		'supernamuwiki' => 'c2',
 		'tmewiki' => 'c2',
 	),


### PR DESCRIPTION
c1 is default anyway. Attempt to fix: T1762
Made as a PR as I'm not sure what the consequences are and someone with DB access should merge, in case something happens.