### PR TITLE
Move TorBlock to GlobalExtensions

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -35,6 +35,7 @@ wfLoadExtensions( [
 	'Timeline',
 	'Thanks',
 	'TitleBlacklist',
+	'TorBlock',
 	'WikiEditor',
 	'cldr'
 ] );

--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -519,10 +519,6 @@ if ( $wmgUseTitleKey ) {
 	wfLoadExtension( 'TitleKey' );
 }
 
-if ( $wmgUseTorBlock ) {
-	wfLoadExtension( 'TorBlock' );
-}
-
 if ( $wmgUseUserWelcome ) {
 	require_once( "$IP/extensions/SocialProfile/SocialProfile.php" );
     require_once( "$IP/extensions/SocialProfile/UserWelcome/UserWelcome.php" );

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1952,9 +1952,6 @@ $wgConf->settings = array(
 		'wisdomwikiwiki' => true,
 		'wisdomsandboxwiki' => true,
 	),
-	'wmgUseTorBlock' => array(
-		'default' => true,
-	),
 	'wmgUseTranslate' => array(
 		'default' => false,
 		'3dicwiki' => true,


### PR DESCRIPTION
TorBlock has been in LocalSettings with default = true for a while now, I disabled it on WikiCanada and then was immediately spammed. I think that it is something Miraheze should have globally