### PR TITLE
Allow crats to modify CVT + allow CVT to remove themselves

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3603,6 +3603,11 @@ $wgConf->settings = array(
 				'commentadmin',
 			),
 		),
+		'+metawiki' => array(
+			'bureaucrat' => array(
+				'cvt',
+			),
+		),
 		'+trexwiki' => array(
 			'co' => array(
 				'ceo',
@@ -4477,6 +4482,11 @@ $wgConf->settings = array(
 	),
 	'wgGroupsRemoveFromSelf' => array(
 		'default' => array(),
+		'metawiki' => array(
+			'cvt' => array(
+				'cvt',
+			),
+		),
 	),
 	'wgRemoveGroups' => array(
 		'default' => array(
@@ -4569,6 +4579,11 @@ $wgConf->settings = array(
 			),
 			'sysop' => array(
 				'commentadmin',
+			),
+		),
+		'+metawiki' => array(
+			'bureaucrat' => array(
+				'cvt',
 			),
 		),
 		'+pruebawiki' => array(


### PR DESCRIPTION
I think that this is appropriate.

Meta Bureaucrats will almost always be stewards or sysadmins, and there's no reason why CVT's shouldn't be able to remove themselves.