### PR TITLE
Officially restrict WikiCanada

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -795,6 +795,9 @@ $wgConf->settings = array(
 			'user' => true,
 			'sysop' => true,
 		),
+		'+wikicanadawiki' => array(
+			'user' => true,
+		),
 		'+wisdomwikiwiki' => array(
 			'anon' => true,
 			'user' => true,

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -156,6 +156,9 @@ if ( $wgDBname == 'wikicanadawiki' ) {
 	$wgGroupPermissions['*']['writeapi'] = false;
 	$wgGroupPermissions['*']['viewmyprivateinfo'] = false;
 	$wgGroupPermissions['*']['viewmywatchlist'] = false;
+	$wgGroupPermissions['*']['createaccount'] = false;
+	$wgGroupPermissions['*']['centralauth-autoaccount'] = false;
+	$wgGroupPermissions['*']['autocreateaccount'] = false;
 	$wgGroupPermissions['sysop']['importupload'] = false;
 	$wgGroupPermissions['sysop']['import'] = false;
 	$wgGroupPermissions['sysop']['markbotedits'] = false;
@@ -181,6 +184,8 @@ if ( $wgDBname == 'wikicanadawiki' ) {
 	$wgGroupPermissions['user']['move-rootuserpages'] = false;
 	$wgGroupPermissions['user']['movefile'] = false;
 	$wgGroupPermissions['user']['torunblocked'] = false;
+	$wgGroupPermissions['user']['createpage'] = false;
+	$wgGroupPermissions['user']['createtalk'] = false;
 	$wgGroupPermissions['checkuser']['checkuser'] = false;
 	$wgGroupPermissions['checkuser']['checkuser-log'] = false;
 	$wgGroupPermissions['steward']['globalblock'] = false;


### PR DESCRIPTION
Currently being managed by ProtectSite and AbuseFilter but this makes it official