### PR TITLE
Cleanup WikiCanada permission revocations

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4748,9 +4748,6 @@ $wgConf->settings = array(
 		),
 		'wikicanadawiki' => array(
 			'banned' => array(
-				'createtalk' => true,
-				'createpage' => true,
-				'edit' => true,
 				'editmyoptions' => true,
 				'editmyprivateinfo' => true,
 				'editmyusercss' => true,

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -145,9 +145,6 @@ if ( $wgDBname == 'swisscomraidwiki' ) {
 }
 
 if ( $wgDBname == 'wikicanadawiki' ) {
-	$wgGroupPermissions['*']['createtalk'] = false;
-	$wgGroupPermissions['*']['createpage'] = false;
-	$wgGroupPermissions['*']['edit'] = false;
 	$wgGroupPermissions['*']['editmyoptions'] = false;
 	$wgGroupPermissions['*']['editmyprivateinfo'] = false;
 	$wgGroupPermissions['*']['editmyusercss'] = false;


### PR DESCRIPTION
Revoking read automatically revokes creating and editing, so there is no reason to revoke them as well