### PR TITLE
Enable FlaggedRevs and change group permissions in isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1204,6 +1204,7 @@ $wgConf->settings = array(
 	'wmgUseFlaggedRevs' => array(
 		'default' => false,
 		'extloadwiki' => true,
+		'isvwiki' => true,
 		'pruebawiki' => true,
 		'styleguidesheetwiki' => true,
 		'trexwiki' => true,
@@ -2491,6 +2492,13 @@ $wgConf->settings = array(
 			NS_HELP,
 			NS_PROJECT,
 		),
+		'isvwiki' => array(
+			NS_MAIN,
+			NS_FILE,
+			NS_TEMPLATE,
+			NS_CATEGORY,
+			828,
+		),
 		'trexwiki' => array(
 			NS_ARTIKEL,
 			NS_FILE,
@@ -2499,6 +2507,7 @@ $wgConf->settings = array(
 	),
 	'wmgFlaggedRevsProtection' => array(
 		'default' => false,
+		'isvwiki' => true,
 		'pruebawiki' => true,
 		'wikicanadawiki' => true,
 	),
@@ -2508,6 +2517,11 @@ $wgConf->settings = array(
 				'quality' => 1,
 				'levels' => 2,
 				'pristine' => 3,
+			),
+		),
+		'isvwiki' => array(
+			'accuracy' => array(
+				'levels' => 1,
 			),
 		),
 	),
@@ -2539,6 +2553,7 @@ $wgConf->settings = array(
 			'neverBlocked' => true,
 			'maxRevertedEditRatio'=> .05,
 		),
+		'isvwiki' => false,
 		'pruebawiki' => false,
 	),
 	'wmgFlaggedRevsAutoReview' => array(

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4060,6 +4060,29 @@ $wgConf->settings = array(
 				'createpage' => true,
 			),
 		),
+		'+isvwiki' => array(
+			'user' => array(
+				'editmyusercss' => true,
+				'editmyuserjs' => true,
+			),
+			'autoconfirmed' => array(
+				'move' => true,
+			),
+			'bot' => array(
+				'autoreview' => true,
+			),
+			'autopatrolled' => array(
+				'autoreview' => true,
+			),
+			'confirmed' => array(
+				'autoconfirmed' => true,
+				'autoreview' => true,
+				'review' => true,
+				'movefile' => true,
+				'move-categorypages' => true,
+				'move-subpages' => true,
+			)
+		),
 		'+jayuwikiwiki' => array(
 			'autoconfirmed' => array(
 				'move' => true,

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -87,8 +87,11 @@ if ( $wgDBname === 'isvwiki' ) {
 	$wgGroupPermissions['*']['editmyusercss'] = false;
 	$wgGroupPermissions['*']['editmyuserjs'] = false;
 	$wgGroupPermissions['*']['writeapi'] = false;
-	$wgGroupPermissions['user']['editmyusercss'] = true;
-	$wgGroupPermissions['user']['editmyuserjs'] = true;
+	
+	$wgGroupPermissions['user']['move'] = false;
+	$wgGroupPermissions['user']['move-subpages'] = false;
+	$wgGroupPermissions['user']['move-categorypages'] = false;
+	$wgGroupPermissions['user']['movefile'] = false;
 	
 	$wgGroupPermissions['autopatrolled']['autopatrol'] = false;
 	$wgGroupPermissions['bot']['autopatrol'] = false;
@@ -96,12 +99,6 @@ if ( $wgDBname === 'isvwiki' ) {
 	$wgGroupPermissions['autopatrolled']['patrol'] = false;
 	$wgGroupPermissions['confirmed']['patrol'] = false;
 	$wgGroupPermissions['sysop']['patrol'] = false;
-	
-	$wgGroupPermissions['autopatrolled']['autoreview'] = true;
-	$wgGroupPermissions['bot']['autoreview'] = true;
-	$wgGroupPermissions['confirmed']['autoreview'] = true;
-	$wgGroupPermissions['confirmed']['review'] = true;
-	$wgGroupPermissions['confirmed']['autoconfirmed'] = true;
 	
 	unset ( $wgGroupPermissions['autoreview'] );
 	unset ( $wgGroupPermissions['editor'] );

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -83,6 +83,31 @@ if ( $wgDBname === 'houseofettlingarfreyuwiki' ) {
 	$wgGroupPermissions['*']['createpage'] = true;
 }
 
+if ( $wgDBname === 'isvwiki' ) {
+	$wgGroupPermissions['*']['editmyusercss'] = false;
+	$wgGroupPermissions['*']['editmyuserjs'] = false;
+	$wgGroupPermissions['*']['writeapi'] = false;
+	$wgGroupPermissions['user']['editmyusercss'] = true;
+	$wgGroupPermissions['user']['editmyuserjs'] = true;
+	
+	$wgGroupPermissions['autopatrolled']['autopatrol'] = false;
+	$wgGroupPermissions['bot']['autopatrol'] = false;
+	$wgGroupPermissions['sysop']['autopatrol'] = false;
+	$wgGroupPermissions['autopatrolled']['patrol'] = false;
+	$wgGroupPermissions['confirmed']['patrol'] = false;
+	$wgGroupPermissions['sysop']['patrol'] = false;
+	
+	$wgGroupPermissions['autopatrolled']['autoreview'] = true;
+	$wgGroupPermissions['bot']['autoreview'] = true;
+	$wgGroupPermissions['confirmed']['autoreview'] = true;
+	$wgGroupPermissions['confirmed']['review'] = true;
+	$wgGroupPermissions['confirmed']['autoconfirmed'] = true;
+	
+	unset ( $wgGroupPermissions['autoreview'] );
+	unset ( $wgGroupPermissions['editor'] );
+	unset ( $wgGroupPermissions['reviewer'] );
+}
+
 if ( $wgDBname === 'intpwiki' ) {
 	$wgGroupPermissions['*']['createpage'] = false;
 	$wgGroupPermissions['user']['createpage'] = false;


### PR DESCRIPTION
Group permissions:
- Stop editing of CSS/JS by anons
- Remove default patrolling from pages
- Replace it with FlaggedRevs-based settings for same groups
- Move restrictions for users

FlaggedRevs:
- Articles/Files/Templates/Categories/Modules for review
- Protection-like settings
- One status setting
- No autopromotion