### PR TITLE
Fixed another error in isvwiki config

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2522,6 +2522,8 @@ $wgConf->settings = array(
 		'isvwiki' => array(
 			'status' => array(
 				'levels' => 1,
+				'quality' => 2,
+				'pristine' => 4,
 			),
 		),
 	),
@@ -4081,7 +4083,7 @@ $wgConf->settings = array(
 				'movefile' => true,
 				'move-categorypages' => true,
 				'move-subpages' => true,
-			)
+			),
 		),
 		'+jayuwikiwiki' => array(
 			'autoconfirmed' => array(


### PR DESCRIPTION
- All levels added
- Comma in confirmed

Sorry again for being an inconvenience, looked into https://noc.wikimedia.org/conf/highlight.php?file=flaggedrevs.php again - there should have been all levels all along since they just modified theirs.

This again fixes #1508 / #1509.