### PR TITLE
Enable TemplateSandbox on isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1882,6 +1882,7 @@ $wgConf->settings = array(
 		'default' => false,
 		'bigforestwiki' => true,
 		'extloadwiki' => true,
+		'isvwiki' => true,
 		'jayuwikiwiki' => true,
 		'modularwiki' => true,
 	),


### PR DESCRIPTION
Don't really know why it isn't enabled by default, but.