### PR TITLE
Enable YouTube Extension in "mikrodevdocswiki" for T1877

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2401,6 +2401,7 @@ $wgConf->settings = array(
 		'luckandlogicwiki' => true,
 		'marcoschriekwiki' => true,
 		'mikrodevwiki' => true,
+		'mikrodevdocswiki' => true,
 		'modularwiki' => true,
 		'muckhackwiki' => true,
 		'ndnwiki' => true,


### PR DESCRIPTION
Enable YouTube Extension in "mikrodevdocswiki" for Request in Phabricator Task [T1877](https://phabricator.miraheze.org/T1877). Thanks.