### PR TITLE
Enable VisualEditor Extension in "pfsolutionswiki" for T1887

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2191,6 +2191,7 @@ $wgConf->settings = array(
 		'patch153wiki' => true,
 		'pbmwiki' => true,
 		'permanentfuturelabwiki' => true,
+		'pfsolutionswiki' => true,
 		'pgnwikiwiki' => true,
 		'plasticssongcontestwiki' => true,
 		'pqwiki' => true,


### PR DESCRIPTION
Enable VisualEditor Extension in "pfsolutionswiki" for Phabricator Task [T1887](https://phabricator.miraheze.org/T1887). Thanks.