### PR TITLE
2 extensions (isvwiki) & global setting for TemplateSandbox

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1095,6 +1095,7 @@ $wgConf->settings = array(
 		'allthetropeswiki' => true,
 		'extloadwiki' => true,
 		'inkubatorwiki' => true,
+		'isvwiki' => true,
 		'rpgbrigadewiki' => true,
 	),
 	'wmgUseDuplicator' => array(
@@ -2491,7 +2492,7 @@ $wgConf->settings = array(
 			NS_FILE,
 			NS_TEMPLATE,
 			NS_CATEGORY,
-			828,
+			WMG_NS_MODULE,
 		),
 		'trexwiki' => array(
 			NS_ARTIKEL,
@@ -3334,6 +3335,12 @@ $wgConf->settings = array(
 	),
 	'+wgNamespaceProtection' => array(
 		'default' => array(),
+		'+isvwiki' => array(
+			// Forum talk
+			111 => array(
+				'editinterface'
+			),
+		),
 		'+nenawikiwiki' => array(
 			NS_MAIN => array(
 				'edit-admin-pages',
@@ -5348,6 +5355,14 @@ $wgConf->settings = array(
 		'wisdomsandboxwiki' => "//$wmgUploadHostname/wisdomsandboxwiki/b/be/Sandbox_Logo.png",
 	),
 
+	// TemplateSandbox
+	'wgTemplateSandboxEditNamespaces' => array(
+		'default' => array(
+			NS_TEMPLATE,
+			WMG_NS_MODULE
+		)
+	),
+	
 	// Timezone
 	'wgLocaltimezone' => array(
 		'default' => 'UTC',
@@ -5496,6 +5511,7 @@ $wgConf->settings = array(
 		'default' => true,
 		'allthetropeswiki' => false,
 		'bttestwiki' => true,
+		'isvwiki' => true,
 		'panoramawiki' => false,
 		'testwiki' => false,
 	),
@@ -5538,8 +5554,12 @@ $wgConf->settings = array(
 			NS_TEST => true,
 		),
 	),
+	'wgVisualEditorShowBetaWelcome' => array(
+		'default' => true,
+		'isvwiki' => false,
+	),
 	'wgVisualEditorSupportedSkins' => array(
-		'defualt' => array(),
+		'default' => array(),
 		'fusewiki' => array( 'foreground' ),
 		'permanentfuturelabwiki' => array( 'foreground' ),
 	),
@@ -5548,6 +5568,7 @@ $wgConf->settings = array(
 		'coldbloodedwiki' => true,
 		'espiralwiki' => true,
 		'fbwikiwiki' => true,
+		'isvwiki' => true,
 		'spiralwiki' => true,
 	),
 	'wmgFlowEditorList' => array(


### PR DESCRIPTION
- Minor style changes ("defualt", 828 changed to WMG_NS_MODULE)
- Added DPLForum with configuration to stop editing forum talks (namespace 111).
- Added VisualEditor with config settings (UseSingleEditTab = true, ShowBetaWelcome = false). Standard config for ShowBetaVelcome: https://www.mediawiki.org/wiki/Extension:VisualEditor#Complete_list_of_configuration_options
- Added Module namespace to be globally in wgTemplateSandboxEditNamespaces since Scribunto is used globally, see https://noc.wikimedia.org/conf/CommonSettings.php.txt for the same configuration in Wikimedia projects.

Before approving this request please go into Parsoid repository and add "isv" there (I hope it is not an inconvenience, I just don't want to make another fork).