### PR TITLE
Remotion of Empty Group in "testwiki"

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3724,7 +3724,6 @@ $wgConf->settings = array(
 		),
 		'+testwiki' => array(
 			'bureaucrat' => array(
-				'testgroup',
 				'bureaucrat',
 				'sysop',
 				'confirmed',
@@ -3735,7 +3734,6 @@ $wgConf->settings = array(
 				'bot',
 				'bureaucrat',
 				'consul',
-				'testgroup',
 				'sysop',
 				'confirmed',
 				'autopatrolled',


### PR DESCRIPTION
Remotion of Empty Group "testgroup" in "testwiki" for solved "Remove groups: and Bots". Thanks.