### PR TITLE
Allow wiki admins to add/remove interwiki prefixes

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4263,6 +4263,7 @@ $wgConf->settings = array(
 				'abusefilter-revert' => true,
 				'deletelogentry' => true,
 				'deleterevision' => true,
+				'interwiki' => true,
 				'rollback' => true,
 			),
 			'user' => array(


### PR DESCRIPTION
It seems to work now without adding to the global table (excluding metawiki)