### PR TITLE
Remove old translate config

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -546,10 +546,6 @@ if ( $wmgUseTranslate ) {
 	$wgGroupPermissions['sysop']['translate-manage'] = true;
 	$wgGroupPermissions['*']['translate'] = true;
 	$wgGroupPermissions['user']['translate-messagereview'] = true;
-	$wgGroupPermissions['translate-proofr']['translate-messagereview'] = false;
-	$wgAddGroups['translate-proofr'] = false;
-	// unset this unused group already
-	unset( $wgGroupPermissions['translate-proofr'] );
 	$wgTranslateBlacklist = $wmgTranslateBlacklist;
 	$wgTranslateTranslationServices = $wmgTranslateTranslationServices;
 	$wgTranslateDocumentationLanguageCode = $wmgTranslateDocumentationLanguageCode;


### PR DESCRIPTION
Translate has changed plenty since we installed it. Translate-proofr was removed as seen in https://github.com/wikimedia/mediawiki-extensions-Translate/commit/2b1dc092f00380bfc0c07ba3118391c86df8e6cf . With the current config, it just creates an empty translate-proofr user group.