### PR TITLE
Enable YouTube Extension in "lexiquewiki" for T2327

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2810,6 +2810,7 @@ $wgConf->settings = array(
 		'jayuwikiwiki' => true,
 		'janesskillspackwiki' => true,
 		'lifewiki' => true,
+		'lexiquewiki' => true,
 		'luckandlogicwiki' => true,
 		'marcoschriekwiki' => true,
 		'mikrodevwiki' => true,


### PR DESCRIPTION
Enable YouTube Extension in "lexiquewiki" for Phabricator Task [T2327](https://phabricator.miraheze.org/T2327). Thanks.