### PR TITLE
Enable Comments Extension in "paddelnwiki" for T2325

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1207,6 +1207,7 @@ $wgConf->settings = array(
 		'jayuwikiwiki' => true,
 		'macfan4000wiki' => true,
 		'muckhackwiki' => true,
+		'paddelnwiki' => true,
 		'pgnwikiwiki' => true,
 		'plazmaburstwiki' => true,
 		'priyowiki' => true,


### PR DESCRIPTION
Enable Comments Extension in "paddelnwiki" for Phabricator Task [T2325](https://phabricator.miraheze.org/T2325). Thanks.