### PR TITLE
On wiki change

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4597,6 +4597,7 @@ $wgConf->settings = array(
 				'consul',
 				'testgroup',
 				'sysop',
+				'authenable',
 				'confirmed',
 				'autopatrolled',
 				'rollbacker',
@@ -5321,6 +5322,12 @@ $wgConf->settings = array(
 			'testgroup' => array(
 				'read' => true,
 			),
+			'authenable' => array(
+				'oathauth-enable' => true,
+			),
+			'sysadmin' => array(
+				'userrights' => true,
+			),			
 		),
 		'+sdiywiki' => array(
 			'sysop' => array(
@@ -5712,6 +5719,7 @@ $wgConf->settings = array(
 				'bureaucrat',
 				'testgroup',
 				'sysop',
+				'authenable',
 				'confirmed',
 				'autopatrolled',
 				'rollbacker',

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -201,6 +201,7 @@ if ( $wgDBname === 'reviwikiwiki' ) {
 }
 
 if ( $wgDBname === 'sau226wiki' ) {
+	$wgGroupPermissions['*']['oathauth-enable'] = false;	
 	$wgGroupPermissions['sysop']['abusefilter-modify-restricted'] = false;
 	$wgGroupPermissions['sysop']['editinterface'] = false;
 	$wgGroupPermissions['sysop']['globalblock-whitelist'] = false;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -201,7 +201,11 @@ if ( $wgDBname === 'reviwikiwiki' ) {
 }
 
 if ( $wgDBname === 'sau226wiki' ) {
-	$wgGroupPermissions['*']['oathauth-enable'] = false;	
+	$wgGroupPermissions['*']['oathauth-enable'] = false;
+	$wgGroupPermissions['steward']['centralauth-lock'] = false;
+	$wgGroupPermissions['steward']['globalblock'] = false;
+	$wgGroupPermissions['steward']['centralauth-oversight'] = false;
+	$wgGroupPermissions['steward']['centralauth-unmerge'] = false;	
 	$wgGroupPermissions['sysop']['abusefilter-modify-restricted'] = false;
 	$wgGroupPermissions['sysop']['editinterface'] = false;
 	$wgGroupPermissions['sysop']['globalblock-whitelist'] = false;


### PR DESCRIPTION
I'd like a couple of new user groups created. This request allows consuls to assign a group that lets a user enable 2 factor authentication and disables the enabling (not the use or disabling) of 2 factor authentication for everyone who isn't a group member. This also creates a sysadmin group which should be self assigned by a sysadmin or assigned by a steward to a sysadmin if they join the wiki and I or a community member send a request for the flagging.