### PR TITLE
LocalSettings.php: add 'WhitelistRead' for 'jawptestwiki'

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -7151,7 +7151,7 @@ $wgConf->settings = array(
 			'Special:CreateAccount',
 		),
 	),
-	
+
 	// Empty arrays (do not touch unless you know what you're doing)
 	'wmgClosedWiki' => array(
 		'default' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -7144,6 +7144,14 @@ $wgConf->settings = array(
 		'wisdomsandboxwiki' => 'freenodeChat',
 	),
 
+	// WhitelistRead for private wikis
+	'+wgWhitelistRead' => array(
+		'default' => array(),
+		'+jawptestwiki' => array(
+			'Special:CreateAccount',
+		),
+	),
+	
 	// Empty arrays (do not touch unless you know what you're doing)
 	'wmgClosedWiki' => array(
 		'default' => false,


### PR DESCRIPTION
Allow read 'Special:CreateAccount' by anon users at 'jawptestwiki'.
Requested by site owner.