### PR TITLE
remove MediaWiki:Common.css from whitelist

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -388,7 +388,6 @@ if ( $wmgUseMainPageWhitelist ) {
 			"Hauptseit",
 			"Accueil",
 			"Halaman Utama",
-			"MediaWiki:Common.css",
 			"特別:アカウント作成"
 	);
 }


### PR DESCRIPTION
it's already in by default