### PR TITLE
Remove php 5.5 check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.5
   - 5.6
 
 script:


### PR DESCRIPTION
No point in checking PHP 5.5 as it's not supported in MediaWiki 1.30 anyway.