### PR TITLE
enable VisualEditor on namespaces in unionwiki and wiki1776wiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -7249,7 +7249,8 @@ $wgConf->settings = array(
 			NS_FILE => true,
 		),
 		'+unionwiki' => array(
-			NS_4 => true,
+			NS_PROJECT => true,
+			NS_PROJECT_TALK => true,
 			NS_PÁGINA => true,
 			NS_PÁGINA_TALK => true,
 			NS_PRUEBA => true,
@@ -7268,7 +7269,8 @@ $wgConf->settings = array(
 			NS_MODELO_TALK => true,
 		),
 		'+wiki1776wiki' => array(
-			NS_4 => true,
+			NS_PROJECT => true,
+			NS_PROJECT_TALK => true,
 			NS_PÁGINA => true,
 			NS_PÁGINA_TALK => true,
 			NS_PRUEBA => true,


### PR DESCRIPTION
**I noticed** that the name **Project** in English translated is **Proyecto** that is enabled, **See** [2071](https://github.com/miraheze/mw-config/pull/2071). It is to enable **namespace 4**