### PR TITLE
settings relatedarticles on allthetropeswiki per req T2710

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6224,6 +6224,10 @@ $wgConf->settings = array(
 	),
 
 	// RelatedArticles settings
+	'wgRelatedArticlesFooterWhitelistedSkins' => array(
+		'default' => 'minerva',
+	        'allthetropeswiki' => 'vector',
+	
 	'wgRelatedArticlesLoggingSamplingRate' => array(
 		'default' => false,
 		'allthetropeswiki' => '0.01',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6227,7 +6227,7 @@ $wgConf->settings = array(
 	'wgRelatedArticlesFooterWhitelistedSkins' => array(
 		'default' => 'minerva',
 	        'allthetropeswiki' => 'vector',
-	
+	),
 	'wgRelatedArticlesLoggingSamplingRate' => array(
 		'default' => false,
 		'allthetropeswiki' => '0.01',


### PR DESCRIPTION


On request in T2710 : 

> $wgRelatedArticlesFooterWhitelistedSkins = ['vector'];

Is the format correct?