### PR TITLE
Remove skin Monaco

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -355,10 +355,6 @@ if ( $wmgUseModernSkylight ) {
 	wfLoadSkin( 'ModernSkylight' );
 }
 
-if ( $wmgUseMonaco ) {
-	require_once( "$IP/skins/Monaco/monaco.php" );
-}
-
 if ( $wmgUseMsPackage ) {
 	wfLoadExtension( 'MsUpload' );
 	wfLoadExtension( 'MsLinks' );

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1965,11 +1965,6 @@ $wgConf->settings = array(
 		'test1wiki' => true,
 		'jayuwikiwiki' => true,
 	),
-	'wmgUseMonaco' => array(
-		'default' => false,
-		'allthetropeswiki' => true,
-		'test1wiki' => true,
-	),
 	'wmgUseMsPackage' => array(
 		'default' => false, // do not set this to false without disabling MsUpload on all wikis below
 		'calexitwiki' => true,

--- a/extension-list
+++ b/extension-list
@@ -178,7 +178,6 @@ $IP/skins/Metrolook/skin.json
 $IP/skins/MinervaNeue/skin.json
 $IP/skins/Modern/skin.json
 $IP/skins/ModernSkylight/skin.json
-$IP/skins/Monaco/monaco.php
 $IP/skins/MonoBook/skin.json
 $IP/skins/Nostalgia/skin.json
 $IP/skins/Refreshed/skin.json


### PR DESCRIPTION
This skin is ancient and also does not work with at least mediawiki 1.30

see example url https://allthetropes.org/w/index.php?title=Main_Page&action=edit&useskin=monaco

It is a white screen with no content thus meaning the skin is broken.