### PR TITLE
Extra language name/prefix for isvwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -138,6 +138,9 @@ if ( $wgDBname === 'ipolywiki' ) {
 }
 
 if ( $wgDBname === 'isvwiki' ) {
+	$wgExtraLanguageNames['isv'] = 'Medžuslovjansky';
+	$wgExtraInterlanguageLinkPrefixes = [ 'd' ];
+
 	$wgSimpleFlaggedRevsUI = false;
 	
 	$wgGroupPermissions['*']['editmyusercss'] = false;


### PR DESCRIPTION
I've read documentation and decided to experiment with this approach to language customization.

1. Add custom `isv` language, so I could change the language from Canadian English as it is now: https://www.mediawiki.org/wiki/Manual:$wgExtraLanguageNames
1. Add `d` to interwiki links list so we could display and set Wikidata items in "In other languages" section: https://www.mediawiki.org/wiki/Manual:$wgExtraInterlanguageLinkPrefixes

Both changes should not affect other projects.