### PR TITLE
Grant privileges to Abuse Team on metawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3893,6 +3893,7 @@ $wgConf->settings = array(
 		'+metawiki' => array(
 			'abuse' => array(
 				'centralauth-lock' => true,
+				'centralauth-oversight' => true,				
 				'centralauth-rename' => true,				
 				'globalblock' => true,
 				'managewiki' => true,


### PR DESCRIPTION
This patch allows abuse team members to use 2 centralauth features: global account rename and global account oversight.

Global oversight is to be used to hide abusive usernames at the CentralAuth account level when necessary
Global rename is in case an abusive username or normal username needs to be renamed as part of the Abuse Team's duties