### PR TITLE
Allow abuse team to oversight usernames

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3894,6 +3894,7 @@ $wgConf->settings = array(
 		'+metawiki' => array(
 			'abuse' => array(
 				'centralauth-lock' => true,
+				'centralauth-oversight' => true,				
 				'globalblock' => true,
 				'managewiki' => true,
 				'managewiki-restricted' => true,


### PR DESCRIPTION
Patch to allow abuse team to oversight inappropriate usernames if necessary as part of their duties