### PR TITLE
Set wgNoticeProject to be a string and not a array

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -18,7 +18,7 @@ if ( isset( $wgConf->settings['wmgClosedWiki'][$wgDBname] ) ) {
 		),
 	);
 
-	$wgNoticeProject[] = 'closed';
+	$wgNoticeProject = 'closed';
 
 	$wgHooks['SiteNoticeAfter'][] = 'onClosedSiteNoticeAfter';
 	function onClosedSiteNoticeAfter( &$siteNotice, $skin ) {
@@ -53,7 +53,7 @@ if ( isset( $wgConf->settings['wmgPrivateWiki'][$wgDBname] ) ) {
 	$wgRemoveGroups['bureaucrat'][] = 'member';
 	$wgRemoveGroups['sysop'][] = 'member';
 
-	$wgNoticeProject[] = 'private';
+	$wgNoticeProject = 'private';
 
 	// To be removed once restbase supports private wiki's
 	$wgDefaultUserOptions['math'] = 'png';


### PR DESCRIPTION
per docs at https://www.mediawiki.org/wiki/Extension:CentralNotice#Quick_developer_setup it shows wgNoticeProject as a string and not a array