### PR TITLE
Remove redundant userrights

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4745,8 +4745,6 @@ $wgConf->settings = array(
  				'editinterface' => true,
  				'editusercss' => true,
  				'edituserjs' => true,
- 				'protectsite' => true,
- 				'editprojectpage' => true,
  			),
  			'user' => array(
  				'editmyoptions' => true,


### PR DESCRIPTION
I’m not currently using ProtectSite nor project namespace protection, so these rights are redundant