### PR TITLE
Override deletion protection for weatherwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5386,6 +5386,9 @@ $wgConf->settings = array(
 			'delete',
 			'protect',
 		),
+		'weatherwiki' => array(
+			
+		),
 	),
 
 	// Robot policy


### PR DESCRIPTION
Deletion protection is redundant since only sysops can delete anyway