### PR TITLE
Add abusefilter-private-log for stewards

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4931,6 +4931,7 @@ $wgConf->settings = array(
  				'abusefilter-private' => true,
  				'abusefilter-hide-log' => true,
  				'abusefilter-hidden-log' => true,
+				'abusefilter-private-log' => true,
 				'oathauth-enable' => true,
  			),
  			'researcher' => array(


### PR DESCRIPTION
This allows stewards to access Special:Log/abusefilterprivatedetails, which is a new log that logs each time the abusefilter-private permission is executed. I believe (haven’t actually seen what the log looks like) that the log works similarly to the CheckUser log.