### PR TITLE
Implement changes requested in T3454

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4046,6 +4046,13 @@ $wgConf->settings = array(
 				'nenamembers',
 			),
 		),
+		'+newusopediawiki' => array(
+			'bureaucrat' => array(
+				'通常候補者',
+				'技官候補者',
+				'developer',
+			),
+		),
 		'+nonbinarywiki' => array(
 			'sysop' => array(
 				'uploader',
@@ -5623,6 +5630,13 @@ $wgConf->settings = array(
 				'nenamembers',
 			),
 		),
+		'+newusopediawiki' => array(
+			'bureaucrat' => array(
+				'通常候補者',
+				'技官候補者',
+				'developer',
+			),
+		),		
 		'+nonbinarywiki' => array(
 			'sysop' => array(
 				'uploader',


### PR DESCRIPTION
This allows bureaucrats on newusopediawiki to add and remove certain user groups as authorized by Phabricator Task T3454. 

If allowed by policy please rebase merge to allow for the saving of time, only requiring 1 commit and keeping author/contributor lists separate.