### PR TITLE
Temporarily re-enable global blocks on weatherwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2036,7 +2036,6 @@ $wgConf->settings = array(
 	'wgApplyGlobalBlocks' => array(
 		'default' => true,
 		'metawiki' => false,
-		'weatherwiki' => false, // let me do the blocking on my wiki, please.  -Amanda
 	),
 	'wgGlobalBlockingDatabase' => array(
 		'default' => 'centralauth', // use centralauth for global blocks


### PR DESCRIPTION
Usually I want to block everything locally, but given the amount of vandalism/spam today, I’ll re-enable global blocks as a temporary measure