### PR TITLE
Disable global blocks on Weather Wiki again

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2055,6 +2055,7 @@ $wgConf->settings = array(
 	'wgApplyGlobalBlocks' => array(
 		'default' => true,
 		'metawiki' => false,
+		'weatherwiki' => false, // let me do the blocking on my wiki, please
 	),
 	'wgGlobalBlockingDatabase' => array(
 		'default' => 'centralauth', // use centralauth for global blocks


### PR DESCRIPTION
Way, way, way too many global blocks are being made, some of which even overlap each other