### PR TITLE
Remove nominornewtalk from bots

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -420,6 +420,7 @@ if ( $wgDBname === 'weatherwiki' ) {
 	$wgGroupPermissions['*']['abusefilter-log'] = false;
 	$wgGroupPermissions['*']['abusefilter-log-detail'] = false;
 	$wgGroupPermissions['user']['read'] = true;
+	$wgGroupPermsisions['bot']['nominornewtalk'] = false;
  	$wgGroupPermissions['sysop']['markbotedits'] = false;
  	$wgGroupPermissions['sysop']['mergehistory'] = false;
 	$wgGroupPermissions['sysop']['abusefilter-modify-restricted'] = false;


### PR DESCRIPTION
All edits, regardless if bot or not, or if minor or not, should always trigger the new messages prompt