### PR TITLE
add destinoswiki on wgDefaultRobotPolicy

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6174,6 +6174,7 @@ $wgConf->settings = array(
 	// Robot policy
 	'wgDefaultRobotPolicy' => array(
 		'default' => 'index,follow',
+		'destinoswiki' => 'noindex,nofollow',
 		'foodsharinghamburgwiki' => 'noindex,nofollow',
 		'ildrilwiki' => 'noindex,nofollow',
 		'librewiki' => 'noindex,nofollow',


### PR DESCRIPTION
So that it does not appear in the results of external search engines