### PR TITLE
Re-enable DSN on weatherwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1406,7 +1406,6 @@ $wgConf->settings = array(
 	),
 	'wmgUseDismissableSiteNotice' => array(
 		'default' => true,
-		'weatherwiki' => false,
 	),
 	'wmgUseDuskToDawn' => array(
 		'default' => false,


### PR DESCRIPTION
I don’t like not being able to close the global site notice, and I haven’t needed to use a local sitenotice yet