### PR TITLE
rem siteadmin from weatherwiki stewards

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5416,7 +5416,6 @@ $wgConf->settings = array(
  				'checkuser' => true,
  				'checkuser-log' => true,
  				'renameuser' => true,
- 				'siteadmin' => true,
  				'abusefilter-private' => true,
  				'abusefilter-hide-log' => true,
  				'abusefilter-hidden-log' => true,


### PR DESCRIPTION
No longer needed thanks to ProtectSite’s ability to lock the entire wiki indefinitely