### PR TITLE
Override default, not add to default

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2278,7 +2278,7 @@ $wgConf->settings = array(
 				'userrights' => true,
 			),
 		),
-		'+weatherwiki' => array(
+		'weatherwiki' => array(
 			'steward' => array(
 				'userrights' => true,
 				'userrights-interwiki' => true,


### PR DESCRIPTION
The checkuser and oversight rights are grandfathered into the steward group on Weather Wiki and therefore should not exist separately