### PR TITLE
Remove another non-restricted right from MW blacklist

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2378,7 +2378,6 @@ $wgConf->settings = array(
 			'managewiki-restricted',
 			'managewiki-editdefault',
 			'mwoauthmanageconsumer',
-			'mwoauthmanagemygrants',
 			'mwoauthsuppress',
 			'mwoauthviewprivate',
 			'mwoauthviewsuppressed',


### PR DESCRIPTION
This right is granted to all logged in/registered users by default, and therefore does not appear to be sensitive/restricted