### PR TITLE
Revert "Restrict editing of sensitive namespaces on weatherwiki"

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2589,9 +2589,6 @@ $wgConf->settings = array(
 				'managewiki' => true,
 				'managewiki-restricted' => true,
 			),
-			'extendedconfirmed' => array(
-				'edit-restrictednamespace' => true,
-			),
 		),
 		'+yeoksawiki' => array(
 			'sysop' => array(
@@ -3884,17 +3881,6 @@ $wgConf->settings = array(
 		'+whentheycrywiki' => array(
 			NS_USER => array(
 				'edit-userpage',
-			),
-		),
-		'+weatherwiki' => array(
-			NS_TEMPLATE => array(
-				'edit-restrictednamespace',
-			),
-			NS_MODULE => array(
-				'edit-restrictednamespace',
-			),
-			NS_PROJECT => array(
-				'edit-restrictednamespace',
 			),
 		),
 		'+yeoksawiki' => array(
@@ -6515,6 +6501,13 @@ $wgConf->settings = array(
 			'uploader' => array(
 				"&",
 				array( APCOND_AGE, 10 * 86400 ),
+			),
+		),
+		'+weatherwiki' => array(
+			'extendedconfirmed' => array(
+				"&",
+				array( APCOND_EDITCOUNT, 100 ),
+				array( APCOND_AGE, 30 * 86400 ),
 			),
 		),
 	),


### PR DESCRIPTION
Reverts miraheze/mw-config#2442

Somehow that removed the $wgAutopromote configuration for the extendedconfirmed group