### PR TITLE
Add ApprovedRevs and Purge to MWP on weatherwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -162,6 +162,10 @@ if ( $wgDBname === 'swisscomraidwiki' ) {
 
 if ( $wgDBname === 'weatherwiki' ) {
 	$wgAvailableRights[] = 'edit-restrictednamespace';
+	$wgAvailableRights[] = 'approverevisions';
+	$wgAvailableRights[] = 'viewlinktolatest';
+	$wgAvailableRights[] = 'viewapprover',
+	$wgAvailableRights[] = 'purge',
 }
 
 if ( $wgDBname === 'wmaucommwiki' ) {


### PR DESCRIPTION
These are both extensions that I’m interested in using, and by default it seems that nobody has the necessary rights to use the extensions.