### PR TITLE
Add sitenotice opt out for weatherwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4180,6 +4180,7 @@ $wgConf->settings = array(
 	'wmgSiteNoticeOptOut' => array(
 		'default' => false,
 		'nenawikiwiki' => true,
+		'weatherwiki' => true,
 	),
 
 	// Server


### PR DESCRIPTION
For whatever reason DismissableSiteNotice doesn’t seem to be working with the current global sitenotice (it keeps reappearing even after I’ve dismissed it)