### PR TITLE
Add bigdelete to weatherwiki stewards

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2129,6 +2129,7 @@ $wgConf->settings = array(
 				'oathauth-enable' => true,
 				'managewiki' => true,
 				'managewiki-restricted' => true,
+				'bigdelete' => true,
 			),
 		),
 		'+yeoksawiki' => array(


### PR DESCRIPTION
Another “just in case” type of thing that shouldn’t be completely unassigned