### PR TITLE
Update $wmgClosedWiki permissions

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -6,14 +6,11 @@
 if ( isset( $wgConf->settings['wmgClosedWiki'][$wgDBname] ) ) {
 	$wgRevokePermissions = array(
 		'*' => array(
-			'block' => true,
 			'createaccount' => true,
-			'delete' => true,
 			'edit' => true,
 			'protect' => true,
 			'import' => true,
 			'upload' => true,
-			'undelete' => true,
 		),
 	);
 


### PR DESCRIPTION
Even on closed wikis, existing admins/bureaucrats and/or stewards may need to be able to block/unblock and delete/undelete.