### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+# Automatically trims whitespace after the last chars
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+[*.php]
+indent_style = tab
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# .travis.yml needs special care
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This will tell GitHub editor and various other editors (but no vim or nano) to use TAB instead of space.

And other practices covered as well. Correct me if the standards have changed meanwhile.