### PR TITLE
Add UserMerge to local weatherwiki stewards

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2312,6 +2312,7 @@ $wgConf->settings = array(
 				'oathauth-enable' => true,
 				'managewiki' => true,
 				'managewiki-restricted' => true,
+				'usermerge' => true,
 			),
 		),
 		'+yeoksawiki' => array(


### PR DESCRIPTION
Per the installation of UserMerge in #2583 however because of CentralAuth and SUL limitations I do not believe that I am allowed to have this right for myself