### PR TITLE
Add another blacklist right

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2373,6 +2373,7 @@ $wgConf->settings = array(
 				'read',
 				'skipcaptcha',
 				'torunblocked',
+				'centralauth-merge',
 			),
 		),
 	),


### PR DESCRIPTION
If centralauth-merge is removed from the * group it can screw up SUL stuff (when a user creates a global account by creating an account on one wiki, if they then visit another wiki where this right has been removed, their local account won’t be automatically merged in to their global account)