### PR TITLE
Disable “page creation log” for weatherwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2675,6 +2675,10 @@ $wgConf->settings = [
 		'default' => false,
 		'electowikiwiki' => true,
 	],
+	'wgPageCreationLog' => [
+		'default' => true,
+		'weatherwiki' => false,
+	],
 
 	// MobileFrontend [MWCandidate]
 	'wmgMFAutodetectMobileView' => [


### PR DESCRIPTION
Unnecessary and unwanted