### PR TITLE
Include "--logs --uploads" in the DataDump dumps

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -228,6 +228,9 @@ if ( $wmgUseDataDump ) {
 				'script' => "$IP/maintenance/dumpBackup.php",
 				'options' => [
 					'--full',
+					'--logs',
+					'--include-files',
+					'--uploads',
 					'--output',
 					"gzip:${wgDataDumpDirectory}" . '${filename}',
 				],

--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -229,7 +229,6 @@ if ( $wmgUseDataDump ) {
 				'options' => [
 					'--full',
 					'--logs',
-					'--include-files',
 					'--uploads',
 					'--output',
 					"gzip:${wgDataDumpDirectory}" . '${filename}',


### PR DESCRIPTION
This doesn't include the actual file so no copyright concerns. It only includes the log.