### PR TITLE
wgApprovedRevs -> egApprovedRevs

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2082,7 +2082,7 @@ $wgConf->settings = [
 		'default' => false,
 	],
 	// Disable in ManageWiki to require all edits, even those by admins, to be approved
-	'wgApprovedRevsAutomaticApprovals' => [
+	'egApprovedRevsAutomaticApprovals' => [
 		'default' => true,
 	],
 

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -698,7 +698,7 @@ $wgManageWikiSettings = [
 		'section' => 'edit',
 		'help' => 'Shows changes to category membership as an action in Special:RecentChanges',
 	],
-	'wgApprovedRevsAutomaticApprovals' => [
+	'egApprovedRevsAutomaticApprovals' => [
 		'name' => 'Automatically approve new revisions',
 		'from' => 'approvedrevs',
 		'type' => 'check',


### PR DESCRIPTION
extension uses eg prefix instead of wg prefix