### PR TITLE
[DO NOT MERGE] temporarily allow user to dump images

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -112,6 +112,51 @@ if ( $wgDBname === 'ciptamediawiki' ) {
 	$wgUploadPath = "https://$wmgHostname/w/img_auth.php";
 }
 
+if ( $wgDBname === 'genwiki' ) {
+	$wgDataDump = [
+		'xml' => [
+			'file_ending' => '.xml.gz',
+			'generate' => [
+				'type' => 'mwscript',
+				'script' => "$IP/maintenance/dumpBackup.php",
+				'options' => [
+					'--full',
+					'--output',
+					"gzip:${wgDataDumpDirectory}" . '${filename}',
+				],
+			],
+			'limit' => 1,
+			'permissions' => [
+				'view' => 'view-dump',
+				'generate' => 'generate-dump',
+				'delete' => 'delete-dump',
+			],
+		],
+		'image' => [
+			'file_ending' => '.zip',
+			'generate' => [
+				'type' => 'script',
+				'script' => '/usr/bin/zip',
+				'options' => [
+					'-r',
+					$wgDataDumpDirectory . '${filename}',
+					"/mnt/mediawiki-static/${wgDBname}/"
+				],
+			],
+			'limit' => 1,
+			'permissions' => [
+				'view' => 'view-dump',
+				'generate' => 'bureaucrat',
+				'delete' => 'delete-dump',
+			],
+		],
+	];
+
+	$wgAvailableRights[] = 'view-dump';
+	$wgAvailableRights[] = 'generate-dump';
+	$wgAvailableRights[] = 'delete-dump';
+}
+
 if ( $wgDBname === 'hamzawiki' ) {
 	 $wgWhitelistRead[] = [
 		"Rukus"


### PR DESCRIPTION
DO NOT MERGE without @JohnFLewis 's approval.

Due to liability reasons I think this would be the only way to do it?

(Also, don't merge unless I'm around to tell the user to do it)