### PR TITLE
Unset cargo db variable

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -85,11 +85,6 @@ if ( $wmgUseMSCalendar ) {
 
 if ( $wmgUseCargo ) {
 	wfLoadExtension( 'Cargo' );
-	$wgCargoDBname = $wgDBname;
-	$wgCargoDBtype = $wgDBtype;
-	$wgCargoDBserver = "81.4.109.166";
-	$wgCargoDBuser = $wgDBuser;
-	$wgCargoDBpassword = $wgDBpassword;
 }
 
 if ( $wmgUseCategorySortHeaders ) {


### PR DESCRIPTION
This is uneeded as it uses the wiki dbname rather then a shared db and duplicates things.