### PR TITLE
remove weatherwiki config

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2819,7 +2819,7 @@ $wgConf->settings = [
 			'random_quiz' => false,
 		],
 	],
-];
+],
 
 function efGetSiteParams( $conf, $wiki ) {
 	$site = null;

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1853,6 +1853,7 @@ $wgConf->settings = [
 		'+whentheycrywiki' => [
 			'user' => [
 				'edit-create' => true,
+			],
 		],
 		'+yeoksawiki' => [
 			'sysop' => [
@@ -2819,7 +2820,7 @@ $wgConf->settings = [
 			'random_quiz' => false,
 		],
 	],
-],
+];
 
 function efGetSiteParams( $conf, $wiki ) {
 	$site = null;

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -53,23 +53,15 @@ $wgConf->settings = [
 	],
 	'wgAbuseFilterBlockDuration' => [
 		'default' => 'indefinte',
-		'weatherwiki' => '1 week',
 	],
 	'wgAbuseFilterAnonBlockDuration' => [
 		'default' => 2592000,
-		'weatherwiki' => '72 hours',
 	],
 	'wgAbuseFilterRestrictions' => [
 		'default' => [
 			'blockautopromote' => true,
 			'block' => true,
 			'degroup' => true,
-			'rangeblock' => true,
-		],
-		'weatherwiki' => [
-			'blockautopromote' => false,
-			'block' => false,
-			'degroup' => false,
 			'rangeblock' => true,
 		],
 	],
@@ -1240,7 +1232,6 @@ $wgConf->settings = [
 	'wgApplyGlobalBlocks' => [
 		'default' => true,
 		'metawiki' => false,
-		'weatherwiki' => false, // let me do the blocking on my wiki, please
 	],
 	'wgGlobalBlockingDatabase' => [
 		'default' => 'mhglobal', // use mhglobal for global blocks
@@ -1394,9 +1385,6 @@ $wgConf->settings = [
 			'wmincubator',
 			'wikiaincubatorplus',
 		],
-		'+weatherwiki' => [
-			'wikipedia',
-		],
 		'+zhdelwiki' => [
 			'wikipedia',
 			'zhwikipedia',
@@ -1523,11 +1511,6 @@ $wgConf->settings = [
 	],
 	'wgManageWikiPermissionsAdditionalAddGroups' => [
 		'default' => [],
-		'weatherwiki' => [
-			'founder' => [
-				'banned',
-			],
-		],
 		'rf1botwiki' => [
 			'bureaucrat' => [
 				'Repo_Maintainer',
@@ -1870,28 +1853,6 @@ $wgConf->settings = [
 		'+whentheycrywiki' => [
 			'user' => [
 				'edit-create' => true,
-			],
-		],
-		'weatherwiki' => [
-			'steward' => [
-				'userrights' => true,
-				'userrights-interwiki' => true,
-				'hideuser' => true,
-				'suppressrevision' => true,
-				'suppressionlog' => true,
-				'viewsuppressed' => true,
-				'checkuser' => true,
-				'checkuser-log' => true,
-				'renameuser' => true,
-				'abusefilter-private' => true,
-				'abusefilter-private-log' => true,
-				'abusefilter-hide-log' => true,
-				'abusefilter-hidden-log' => true,
-				'oathauth-enable' => true,
-				'managewiki' => true,
-				'managewiki-restricted' => true,
-				'usermerge' => true,
-			],
 		],
 		'+yeoksawiki' => [
 			'sysop' => [
@@ -1901,11 +1862,6 @@ $wgConf->settings = [
 	],
 	'wgManageWikiPermissionsAdditionalRemoveGroups' => [
 		'default' => [],
-		'weatherwiki' => [
-			'founder' => [
-				'banned',
-			],
-		],
 		'rf1botwiki' => [
 			'bureaucrat' => [
 				'Repo_Maintainer',
@@ -1978,7 +1934,6 @@ $wgConf->settings = [
 	],
 	'wgManageWikiPermissionsDefaultPrivateGroup' => [
 		'default' => 'member',
-		'weatherwiki' => 'user',
 	],
 	'wgManageWikiHelpUrl' => [
 		'default' => '//meta.miraheze.org/wiki/ManageWiki',
@@ -2200,20 +2155,6 @@ $wgConf->settings = [
 				'edit' => true,
 			],
 		],
-		'weatherwiki' => [
-			'banned' => [
-				'editmyoptions' => true,
-				'editmyprivateinfo' => true,
-				'editmyusercss' => true,
-				'editmyuserjs' => true,
-				'editmywatchlist' => true,
-				'edit' => true,
-				'read' => true,
-				'writeapi' => true,
-				'viewmyprivateinfo' => true,
-				'viewmywatchlist' => true,
-			],
-		],
 	],
 	'wgImplicitGroups' => [
 		'default' => [ '*', 'user', 'autoconfirmed' ],
@@ -2376,7 +2317,6 @@ $wgConf->settings = [
 			'ceo',
 			'co',
 		],
-		'weatherwiki' => [],
 	],
 
 	//

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -180,10 +180,6 @@ if ( $wgDBname === 'swisscomraidwiki' ) {
 	$wgAutopromote['emailconfirmed'] = APCOND_EMAILCONFIRMED;
 }
 
-if ( $wgDBname === 'weatherwiki' ) {
-	$wgAvailableRights[] = 'edit-restrictednamespace';
-}
-
 if ( $wgDBname === 'wikiageingwiki' ) {
 	$wgForeignFileRepos[] = [
 		'class'                   => 'ForeignAPIRepo',


### PR DESCRIPTION
As I don't have time or the motivation to continue maintaining it, Weather Wiki is going to be deleted within the coming days. This change removes all configuration that I could find in LocalSettings.php pertaining to weather wiki - most of it is "leftover" things that couldn't go in ManageWiki. However, DO NOT MERGE this change right now as I'm still working with DataDump and figuring out how it works, and as such the wiki should NOT be deleted yet.