### PR TITLE
Set wmgUseMobileFrontend to false

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -775,7 +775,7 @@ $wgConf->settings = [
 		'default' => false,
 	],
 	'wmgUseMobileFrontend' => [
-		'default' => true,
+		'default' => false,
 	],
 	'wmgUseModeration' => [
 		'default' => false,


### PR DESCRIPTION
MangeWiki should set it by default for new wikis and existing wikis will have it set to allow them to disable it if they want.

Bug: T4683