### PR TITLE
Remove unnecessary configurations of $wgRightsIcon

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1438,8 +1438,6 @@ $wgConf->settings = [
 	// License
 	'wgRightsIcon' => [
 		'default' => 'https://meta.miraheze.org/w/resources/assets/licenses/cc-by-sa.png',
-		'incubatorwiki' => 'https://meta.miraheze.org/w/resources/assets/licenses/cc-by-sa.png',
-		'isvwiki' => 'https://meta.miraheze.org/w/resources/assets/licenses/cc-by-sa.png',
 		'jadtechwiki' => "//$wmgUploadHostname/jadtechwiki/d/d8/CopyrightIcon.png",
 		'revitwiki' => "//$wmgUploadHostname/revitwiki/d/d8/All_Rights_Reserved.png",
 	],


### PR DESCRIPTION
Because configurations of $wgRightsIcon for `incubatorwiki` and `isvwiki` are exactly same as `default`, they don't need to be defined per-wiki.