### PR TITLE
Adjust protection settings

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2305,9 +2305,11 @@ $wgConf->settings = [
 	],
 
 	// Restriction types
-	'+wgRestrictionLevels' => [
+	'wgRestrictionLevels' => [
 		'default' => [
 			'user',
+			'autoconfirmed',
+			'sysop'
 		],
 		'+bigforestwiki' => [
 			'editvoter',
@@ -2399,11 +2401,12 @@ $wgConf->settings = [
 	],
 	'wgRestrictionTypes' => [
 		'default' => [
+			'create',
 			'edit',
 			'move',
-			'create',
 			'upload',
 			'delete',
+			'protect'
 		],
 	],
 


### PR DESCRIPTION
* It makes sense to sort protection levels by hierarchy, lower to higher like `""`->`autoconfirmed`(->`extendedconfirmed`)->`sysop`, as MediaWiki core (and Wikimedia wikis in case of using `extendedconfirmed` protection level) does. As such, I adjusted [`$wgRestrictionLevels`](https://www.mediawiki.org/wiki/Manual:$wgRestrictionLevels) to display `user` protection level ("Allow only logged in users") before `autoconfirmed` and `sysop` protection levels.
* I also reordered `'create'` in [`$wgRestrictionTypes`](https://www.mediawiki.org/wiki/Manual:$wgRestrictionTypes) to be before other options since it matches better to default settings and "creating" a page is done before "editing", and enabled protecting pages from changing protection settings by default.