### PR TITLE
Remove duplicate foreach

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2991,14 +2991,10 @@ foreach ( $wmgDatabaseList as $wikiLine ) {
 }
 
 foreach ( $wgConf->settings['wgServer'] as $name => $val ) {
-	if ( $val === 'https://' . $wmgHostname ) {
+	$mobileDomain = isset( $wgConf->settings['wgMobileUrlTemplate'][$name] )
+		&& $wgConf->settings['wgMobileUrlTemplate'][$name];
+	if ( $val === 'https://' . $wmgHostname || $mobileDomain === $wmgHostname ) {
 		$wgDBname = $name;
-	}
-}
-
-foreach ( $wgConf->settings['wgMobileUrlTemplate'] as $value => $mobileurl ) {
-	if ( $mobileurl === $wmgHostname ) {
-		$wgDBname = $value;
 	}
 }
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2991,8 +2991,8 @@ foreach ( $wmgDatabaseList as $wikiLine ) {
 }
 
 foreach ( $wgConf->settings['wgServer'] as $name => $val ) {
-	$mobileDomain = isset( $wgConf->settings['wgMobileUrlTemplate'][$name] )
-		&& $wgConf->settings['wgMobileUrlTemplate'][$name];
+	$mobileDomain = isset( $wgConf->settings['wgMobileUrlTemplate'][$name] ) ?
+		$wgConf->settings['wgMobileUrlTemplate'][$name] : false;
 	if ( $val === 'https://' . $wmgHostname || $mobileDomain === $wmgHostname ) {
 		$wgDBname = $name;
 	}

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2990,11 +2990,20 @@ foreach ( $wmgDatabaseList as $wikiLine ) {
 	}
 }
 
+$middleMobile = false;
+
+// TODO: Convert this so that we use the url to find the wikiname,
+// will lead to performance increase as we won't need to foreach.
 foreach ( $wgConf->settings['wgServer'] as $name => $val ) {
 	$mobileDomain = isset( $wgConf->settings['wgMobileUrlTemplate'][$name] ) ?
 		$wgConf->settings['wgMobileUrlTemplate'][$name] : false;
 	if ( $val === 'https://' . $wmgHostname || $mobileDomain === $wmgHostname ) {
 		$wgDBname = $name;
+		// There is an issue where setting it staticly (e.g *.m.*) would not generate
+		// a mobile link. Workaround this by using %h0.m.%h1.%h2.
+		if ( preg_match( '/^(.+)\.m\.(.+)$/', $mobileDomain, $matches ) ) {
+			$middleMobile = '%h0.m.%h1.%h2';
+		}
 	}
 }
 
@@ -3026,6 +3035,10 @@ if ( preg_match( '/^(.*)\.miraheze\.org$/', $wmgHostname, $matches ) ) {
 	$wgMobileUrlTemplate = '%h0.m.miraheze.org';
 } elseif ( preg_match( '/^(.*)\.m\.miraheze\.org$/', $wmgHostname, $matches ) ) {
 	$wgMobileUrlTemplate = '%h0.m.miraheze.org';
+}
+
+if ( $middleMobile ) {
+	$wgMobileUrlTemplate = $middleMobile;
 }
 
 if ( !preg_match( '/^(.*)\.miraheze\.org$/', $wmgHostname, $matches ) ) {

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3001,7 +3001,7 @@ foreach ( $wgConf->settings['wgServer'] as $name => $val ) {
 		$wgDBname = $name;
 		// There is an issue where setting it staticly (e.g *.m.*) would not generate
 		// a mobile link. Workaround this by using %h0.m.%h1.%h2.
-		if ( preg_match( '/^(.+)\.m\.(.+)$/', $mobileDomain, $matches ) ) {
+		if ( $mobileDomain && preg_match( '/^(.+)\.m\.(.+)$/', $mobileDomain, $matches ) ) {
 			$middleMobile = '%h0.m.%h1.%h2';
 		}
 	}


### PR DESCRIPTION
No need to do an extra foreach when we can use $name.

Also fix an issue with custom wiki domains that use *.m.*.