### PR TITLE
Enable wgMiserMode

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -530,6 +530,11 @@ $wgConf->settings = [
 		'default' => 110,
 	],
 
+	// https://www.mediawiki.org/wiki/Manual:$wgMiserMode
+	'wgMiserMode' => [
+		'default' => true,
+	],
+
 	// Extensions and Skins
 	'wmgUse3D' => [
 		'default' => false,


### PR DESCRIPTION
Per documentation https://www.mediawiki.org/wiki/Manual:$wgMiserMode, this is designed to reduce load (for wiki farms or large wikis).

Switching this on means that the query cache is now used and so we have to run a cron on all wikis (which will be done every 3 months).