### PR TITLE
Prevent crat from editing interwiki admin group

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2039,6 +2039,7 @@ $wgConf->settings = [
 			'oversight',
 			'steward',
 			'staff',
+			'interwiki-admin',
 		],
 	],
 	'wgManageWikiPermissionsDefaultPrivateGroup' => [


### PR DESCRIPTION
Current a wiki bureaucrat can use manage wiki to modify the local interwiki admin group because it is not blacklisted. Due the frankly ridiculous requirements currently in place for getting the interwiki permission I assume this is not desired. Now I don't see why this permission is restricted in the first place when editinterface already allows adding malicious content if desired, but here is the fix anyway because even though I don't agree with the rules I am never one to abuse exploits or break rules and I gueuely care for miraheze and want to see it continue to thrive for years to come. Note while I did add myself to the group on my wiki I only did it as a test, I did not change the interwiki table at all and I removed the group as soon as I confirmed it could be done, the logs should be able to confirm this if anyone is suspicious for any reason. Thank you.