### PR TITLE
restore access to editothersprofiles

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1984,7 +1984,6 @@ $wgConf->settings = [
 				'checkuser-log',
 				'createwiki',
 				'editincidents',
-				'editothersprofiles',
 				'editothersprofiles-private',
 				'flow-suppress',
 				'globalblock',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1619,7 +1619,8 @@ $wgManageWikiExtensions = [
 						'permissions' => [
 							'awardsmanage',
 							'giftadmin',
-							'avatarremove'
+							'avatarremove',
+							'editothersprofiles'
 						],
 					],
 				],


### PR DESCRIPTION
this right no longer provides access to private information since the introduction of editothersprofiles-private