### PR TITLE
Disable Approved Revs extension in several namespaces on UcroniasWiki…

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1185,6 +1185,20 @@ $wgConf->settings = [
 			NS_HELP => false,
 			NS_PROJECT => false
 		],
+ 		'hispanowiki' => [
+			NS_USER => false,
+ 			NS_FILE => false,
+			NS_TEMPLATE => false,
+			NS_HELP => false,
+			NS_PROJECT => false
+		],
+ 		'ucroniaswiki' => [
+			NS_USER => false,
+ 			NS_FILE => false,
+			NS_TEMPLATE => false,
+			NS_HELP => false,
+			NS_PROJECT => false
+		],
 	],
 
 	// FlaggedRevs


### PR DESCRIPTION
… and HispanoWiki

Because they are not content pages