### PR TITLE
wgNamespaceRobotPolicies on hispanowiki and ucronias

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2513,6 +2513,17 @@ $wgConf->settings = [
 		'horizonwiki' => [
 			'NS_MAIN' => 'index,follow'
 		],
+		'hispanowiki' => [
+			'NS_TEMPLATE' => 'noindex,nofollow',
+			'NS_GUÍA' => 'noindex,nofollow',
+			'NS_WIKIPEDIA' => 'noindex,nofollow',
+			'NS_PROPUESTA' => 'noindex,nofollow',
+			'NS_NOTICIA' => 'noindex,nofollow',
+		],
+		'ucroniaswiki' => [
+			'NS_TEMPLATE' => 'noindex,nofollow',
+			'NS_ANEXO' => 'index,follow',
+		],
 	],
 
 	// Referrer Policy


### PR DESCRIPTION
Avoid indexing pages that are not content. In addition to forcing the indexing of a namespace