### PR TITLE
Remove wgMobileUrlTemplate in ManageWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3110,15 +3110,8 @@ $middleMobile = false;
 // TODO: Convert this so that we use the url to find the wikiname,
 // will lead to performance increase as we won't need to foreach.
 foreach ( $wgConf->settings['wgServer'] as $name => $val ) {
-	$mobileDomain = isset( $wgConf->settings['wgMobileUrlTemplate'][$name] ) ?
-		$wgConf->settings['wgMobileUrlTemplate'][$name] : false;
-	if ( $val === 'https://' . $wmgHostname || $mobileDomain === $wmgHostname ) {
+	if ( $val === 'https://' . $wmgHostname) {
 		$wgDBname = $name;
-		// There is an issue where setting it staticly (e.g *.m.*) would not generate
-		// a mobile link. Workaround this by using %h0.m.%h1.%h2.
-		if ( $mobileDomain && preg_match( '/^(.+)\.m\.(.+)$/', $mobileDomain, $matches ) ) {
-			$middleMobile = '%h0.m.%h1.%h2';
-		}
 	}
 }
 
@@ -3145,16 +3138,6 @@ $wgUploadDirectory = "/mnt/mediawiki-static/$wgDBname";
 
 $wgConf->wikis = $wgLocalDatabases;
 $wgConf->extractAllGlobals( $wgDBname );
-
-if ( preg_match( '/^(.*)\.miraheze\.org$/', $wmgHostname, $matches ) ) {
-	$wgMobileUrlTemplate = '%h0.m.miraheze.org';
-} elseif ( preg_match( '/^(.*)\.m\.miraheze\.org$/', $wmgHostname, $matches ) ) {
-	$wgMobileUrlTemplate = '%h0.m.miraheze.org';
-}
-
-if ( $middleMobile ) {
-	$wgMobileUrlTemplate = $middleMobile;
-}
 
 if ( !preg_match( '/^(.*)\.miraheze\.org$/', $wmgHostname, $matches ) ) {
 	$wgCentralAuthCookieDomain = $wmgHostname;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -103,10 +103,6 @@ if ( $wgDBname === 'harrypotterwiki' ) {
 	$wgDefaultUserOptions['collapsiblenav'] = 1;
 }
 
-if ( $wgDBname === 'indoctrinatedwiki' ) {
-	$wgMobileUrlTemplate = '';
-}
-
 if ( $wgDBname === 'isvwiki' ) {
 	$wgExtraLanguageNames['isv'] = 'Medžuslovjansky';
 	$wgExtraInterlanguageLinkPrefixes = [ 'd' ];

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1034,15 +1034,6 @@ $wgManageWikiSettings = [
 		'section' => 'restricted',
 		'help' => 'By default your wiki is available at https://yourwiki.miraheze.org - a subdomain of Miraheze but you can request us to redirect your wiki to a domain you own. Right now is not yet possible to do it without assistance from our sysadmins, but you can learn more here https://meta.miraheze.org/wiki/Custom_domains',
 	],
-	'wgMobileUrlTemplate' => [
-		'name' => 'Mobile URL',
-		'from' => 'mediawiki',
-		'restricted' => true,
-		'type' => 'text',
-		'overridedefault' => '',
-		'section' => 'restricted',
-		'help' => 'This sets your mobile URL. Defaults to [domain].',
-	],
 	'wgDefaultRobotPolicy' => [
 		'name' => 'Default Robot Policy',
 		'from' => 'mediawiki',


### PR DESCRIPTION
We will no longer set mobile domains, instead it will auto detect whether to display the mobile ui and allow users to view the desktop site if they want.