### PR TITLE
Add runcargoqueries as all user perm on Cargo install

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -225,6 +225,11 @@ $wgManageWikiExtensions = [
 					'cargo_tables' => "$IP/extensions/Cargo/sql/Cargo.sql"
 				],
 				'permissions' => [
+					'*' => [
+						'permissions' => [
+							'runcargoqueries',
+						],
+					],
 					'sysop' => [
 						'permissions' => [
 							'recreatecargodata',


### PR DESCRIPTION
runcargoqueries governs access to the special pages Special:Drilldown and Special:ViewData, which allow for viewing/querying of stored Cargo table data using visual forms.

By default, this permission should be enabled for all users: https://github.com/wikimedia/mediawiki-extensions-Cargo/blob/2d48935037fa8626b6365019878d044a9fa52970/extension.json#L20