### PR TITLE
Remove wgJobRunRate - leaving to the default as 1

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1545,11 +1545,6 @@ $wi->config->settings = [
 		],
 	],
 
-	// Job Queue
-	'wgJobRunRate' => [
-		'default' => 0,
-	],
-
 	// Kartographer
 	'wgKartographerWikivoyageMode' => [
 		'default' => false,


### PR DESCRIPTION
Going to see how things are handled by letting the default be used.