### PR TITLE
Adding Calendar-Wikivoyage Extension

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -237,6 +237,10 @@ if ( $wmgUseCSS ) {
 	wfLoadExtension( 'CSS' );
 }
 
+if ( $wmgUseCalendarWikivoyage ) {
+	wfLoadExtension( 'Calendar-Wikivoyage' )
+}
+
 if ( $wmgUseDarkMode ) {
 	wfLoadExtension( 'DarkMode' );
 }

--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -238,7 +238,7 @@ if ( $wmgUseCSS ) {
 }
 
 if ( $wmgUseCalendarWikivoyage ) {
-	wfLoadExtension( 'Calendar-Wikivoyage' )
+	wfLoadExtension( 'Calendar' )
 }
 
 if ( $wmgUseDarkMode ) {

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -684,6 +684,9 @@ $wi->config->settings = [
 	'wmgUseCSS' => [
 		'default' => false,
 	],
+	'wmgUseCalendarWikivoyage' => [
+		'default' => false,
+	],
 	'wmgUseDarkMode' => [
 		'default' => false,
 	],

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -422,6 +422,17 @@ $wgManageWikiExtensions = [
 			'conflicts' => false,
 			'requires' => [],
 		],
+		'calendar-wikivoyage' => [
+			'name' => 'Calendar-Wikivoyage',
+			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Calendar-Wikivoyage',
+			'var' => 'wmgUseCalendarWikivoyage',
+			'conflicts' => false,
+			'requires' => [
+				'permissions' => [
+					'managewiki-restricted',
+				],
+			],
+		],
 		'datatransfer' => [
 			'name' => 'DataTransfer',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Extension:DataTransfer',

--- a/extension-list
+++ b/extension-list
@@ -44,6 +44,7 @@ $IP/extensions/CreatePageUw/extension.json
 $IP/extensions/CreateRedirect/extension.json
 $IP/extensions/CreateWiki/extension.json
 $IP/extensions/CrossReference/extension.json
+$IP/extensions/Calendar/extension.json
 $IP/extensions/DarkMode/extension.json
 $IP/extensions/DataDump/extension.json
 $IP/extensions/DataTransfer/extension.json


### PR DESCRIPTION
Adding Calendar-Wikivoyage extension per phab item T5137. Submodule has not yet been added. I will add comment when it is.