### PR TITLE
Remove restriction on DynamicSidebar extension

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -516,11 +516,7 @@ $wgManageWikiExtensions = [
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:DynamicSidebar',
 			'var' => 'wmgUseDynamicSidebar',
 			'conflicts' => false,
-			'requires' => [
-				'permissions' => [
-					'managewiki-restricted',
-				],
-			],
+			'requires' => [],
 		],
 		'editcount' => [
 			'name' => 'EditCount',


### PR DESCRIPTION
The extension is tested and stable and therefore should not be restricted.