### PR TITLE
Change wgArticlePath for solarawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2774,6 +2774,7 @@ $wi->config->settings = [
 	// Server
 	'wgArticlePath' => [
 		'default' => '/wiki/$1',
+		'solarawiki' => '/$1',
 	],
 	'wgDisableOutputCompression' => [
 		'default' => true,


### PR DESCRIPTION
I'm not certain this won't break anything... like robots.txt. It looks like solarawiki might have Special pages indexed? Anyway we can fix that too?

If it's too much trouble, then don't bother. It'd just be neat to get rid of the /wiki/ given the top-level domain is .wiki (https://spcodex.wiki)