### PR TITLE
Blacklist oathauth-verify-user

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2140,6 +2140,7 @@ $wi->config->settings = [
 				'mwoauthviewprivate',
 				'mwoauthviewsuppressed',
 				'oathauth-disable-for-user',
+				'oathauth-verify-user',
 				'oathauth-view-log',
 				'renameuser',
 				'requestwiki',
@@ -2153,7 +2154,6 @@ $wi->config->settings = [
 				'viewglobalprivatefiles',
 				'viewpmlog',
 				'viewsuppressed',
-				'oathauth-verify-user',
 			],
 			'*' => [
 				'read',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2153,6 +2153,7 @@ $wi->config->settings = [
 				'viewglobalprivatefiles',
 				'viewpmlog',
 				'viewsuppressed',
+				'oathauth-verify-user'
 			],
 			'*' => [
 				'read',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2153,7 +2153,7 @@ $wi->config->settings = [
 				'viewglobalprivatefiles',
 				'viewpmlog',
 				'viewsuppressed',
-				'oathauth-verify-user'
+				'oathauth-verify-user',
 			],
 			'*' => [
 				'read',


### PR DESCRIPTION
Can be merged any time (preferably ASAP).

1.35 allows for checking 2FA status via the oathauth-verify-user right. This must be blacklisted to avoid a privacy leak.

Bug: T5498 (Part 1/2)