### PR TITLE
Remove TLS cert and key from Database.php

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -93,8 +93,12 @@ $wi->config->settings['wgLBFactoryConf']['default'] = [
 		'password' => $wgDBpassword,
 		'type' => 'mysql',
 		'flags' => DBO_SSL | DBO_COMPRESS,
-		'sslCertPath' => '/etc/ssl/certs/wildcard.miraheze.org.crt',
-		'sslKeyPath' => '/etc/ssl/private/wildcard.miraheze.org.key',
+		// MediaWiki checks if the certificate presented by MariaDB is signed
+		// by the certificate authority listed in 'sslCAFile'. In emergencies
+		// this could be set to /etc/ssl/certs/ca-certificates.crt (all trusted
+		// CAs), but setting this to one CA reduces attack vector and CAs
+		// to dig through when checking the certificate provided by MariaDB.
+		'sslCAFile' => '/etc/ssl/certs/Sectigo.crt',
 	],
 	'hostsByName' => [
 		'dbt1' => 'dbt1.miraheze.org',


### PR DESCRIPTION
Since day 1 Miraheze has been relying on passwords (PSKs) to authenticate the mediawiki and wikiadmin users for database connections. As such, there is no point in setting the certificate and key paths here, since we don't use two-way authentication. Avoids log spam, extra traffic, more usage of the wildcard certificate (ideally only used on the cache proxies!) and avoids the impression of using one-way authentication where we don't.

Two-way authentication has its benefits and may be considered in the future, but is not relevant right now.