### PR TITLE
Use actual name of extension

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -27,8 +27,8 @@ $wgManageWikiExtensions = [
 			'conflicts' => false,
 			'requires' => [],
 		],
-		'htmlmetaadntitle' => [
-			'name' => 'HTML Meta and Title',
+		'addhtmlmetaadntitle' => [
+			'name' => 'Add HTML Meta and Title',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Add_HTML_Meta_and_Title',
 			'var' => 'wmgUseAddHTMLMetaAndTitle',
 			'conflicts' => false,


### PR DESCRIPTION
Otherwise we just create confusion, weirdness and an unordered mess