### PR TITLE
blacklist subdomains

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -295,7 +295,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'CreateWikiBlacklistedSubdomains' => [
-		'default' => '^(wiki|www|wikis)+$',
+		'default' => '^(wiki|www|wikis|misc1.*|db.*|cp.*|mw.*|jobrunner.*|gluster.*|ns.*|bacula.*|misc.*|mail.*|mw.*|mon1|lizardfs.*|swift1|swift2|rdb.*|phab.*|services1|services2|puppet.*|test2)+$',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -294,7 +294,7 @@ $wi->config->settings = [
 	],
 
 	// CreateWiki
-	'CreateWikiBlacklistedSubdomains' => [
+	'wgCreateWikiBlacklistedSubdomains' => [
 		'default' => '^(wiki|www|wikis|misc[0-8]|db[0-8]|cp[0-8]|mw[0-8]|jobrunner[0-8]|gluster[0-8]|ns[0-8]|bacula[0-8]|misc[0-8]|mail[0-8]|mw[0-8]|ldap[0-8]|cloud[0-8]|mon[0-8]|lizardfs[0-8]|rdb[0-8]|phab[0-8]|services[0-8]|puppet[0-8]|test[0-8])+$',
 	],
 	'wgCreateWikiCustomDomainPage' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -294,6 +294,9 @@ $wi->config->settings = [
 	],
 
 	// CreateWiki
+	'CreateWikiBlacklistedSubdomains' => [
+		'default' => '^(wiki|www|wikis)+$',
+	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -295,7 +295,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'CreateWikiBlacklistedSubdomains' => [
-		'default' => '^(wiki|www|wikis|misc[0-8]|db[0-8]|cp[0-8]|mw[0-8]|jobrunner[0-8]|gluster[0-8]|ns[0-8]|bacula[0-8]|misc[0-8]|mail[0-8]|mw[0-8]|ldap1|cloud1|cloud2|mon1|lizardfs[0-8]|rdb[0-8]|phab[0-8]|services1|services2|puppet[0-8]|test2)+$',
+		'default' => '^(wiki|www|wikis|misc[0-8]|db[0-8]|cp[0-8]|mw[0-8]|jobrunner[0-8]|gluster[0-8]|ns[0-8]|bacula[0-8]|misc[0-8]|mail[0-8]|mw[0-8]|ldap[0-8]|cloud[0-8]|mon[0-8]|lizardfs[0-8]|rdb[0-8]|phab[0-8]|services[0-8]|puppet[0-8]|test[0-8])+$',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -295,7 +295,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'CreateWikiBlacklistedSubdomains' => [
-		'default' => '^(wiki|www|wikis|misc1.*|db.*|cp.*|mw.*|jobrunner.*|gluster.*|ns.*|bacula.*|misc.*|mail.*|mw.*|ldap.*|cloud1|cloud2|mon1|lizardfs.*|swift1|swift2|rdb.*|phab.*|services1|services2|puppet.*|test2)+$',
+		'default' => '^(wiki|www|wikis|misc1.*|db.*|cp.*|mw.*|jobrunner.*|gluster.*|ns.*|bacula.*|misc.*|mail.*|mw.*|ldap1|cloud1|cloud2|mon1|lizardfs.*|swift1|swift2|rdb.*|phab.*|services1|services2|puppet.*|test2)+$',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -295,7 +295,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'CreateWikiBlacklistedSubdomains' => [
-		'default' => '^(wiki|www|wikis|misc1.*|db.*|cp.*|mw.*|jobrunner.*|gluster.*|ns.*|bacula.*|misc.*|mail.*|mw.*|ldap1|cloud1|cloud2|mon1|lizardfs.*|swift1|swift2|rdb.*|phab.*|services1|services2|puppet.*|test2)+$',
+		'default' => '^(wiki|www|wikis|misc[0-8]|db[0-8]|cp[0-8]|mw[0-8]|jobrunner[0-8]|gluster[0-8]|ns[0-8]|bacula[0-8]|misc[0-8]|mail[0-8]|mw[0-8]|ldap1|cloud1|cloud2|mon1|lizardfs[0-8]|rdb[0-8]|phab[0-8]|services1|services2|puppet[0-8]|test2)+$',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -295,7 +295,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'CreateWikiBlacklistedSubdomains' => [
-		'default' => '^(wiki|www|wikis|misc1.*|db.*|cp.*|mw.*|jobrunner.*|gluster.*|ns.*|bacula.*|misc.*|mail.*|mw.*|mon1|lizardfs.*|swift1|swift2|rdb.*|phab.*|services1|services2|puppet.*|test2)+$',
+		'default' => '^(wiki|www|wikis|misc1.*|db.*|cp.*|mw.*|jobrunner.*|gluster.*|ns.*|bacula.*|misc.*|mail.*|mw.*|ldap.*|cloud1|cloud2|mon1|lizardfs.*|swift1|swift2|rdb.*|phab.*|services1|services2|puppet.*|test2)+$',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',


### PR DESCRIPTION
CreateWiki/RequestWiki will now throw an error when a wiki with the exact name of "wikiwiki", "wwwwiki", or "wikiswiki" is requested.