### PR TITLE
reconfigure TitleBlacklist

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3043,21 +3043,20 @@ $wi->config->settings = [
 	// TitleBlacklist
 	'wgTitleBlacklistSources' => [
 		'default' => [
-			'default' => [
+			'global' => [
 				'type' => 'url',
 				'src'  => 'https://meta.miraheze.org/w/index.php?title=Title_blacklist&action=raw',
-			],
-			'meta' => [
-				'type' => 'url',
-				'src'  => 'https://meta.miraheze.org/w/index.php?title=MediaWiki:Titleblacklist&action=raw',
 			],
 		],
 	],
 	'wgTitleBlacklistUsernameSources' => [
-		'default' => [
-			'default',
-			'meta',
-		],
+		'default' => '*',
+	],
+	'wgTitleBlacklistLogHits' => [
+		'default' => true,
+	],
+	'wgTitleBlacklistBlockAutoAccountCreation' => [
+		'default' => false,
 	],
 	'wgTidyConfig' => [
 		'default' => [


### PR DESCRIPTION
The local page is pulled by default, and there is nothing on meta's MediaWiki:Titleblacklist that isn't already on the global page.

Use all sources as potential username blacklists.

Log TitleBlacklist hits

Do not block automatic account creation