### PR TITLE
Userrights config for simcitywiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2094,7 +2094,6 @@ $wi->config->settings = [
 				'oathauth-view-log' => true,
 			],
 			'user' => [],
-			],
 		],
 		'+sovereignwiki' => [
 			'officer' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2087,11 +2087,7 @@ $wi->config->settings = [
 				'userrights' => true,
 				'usermerge' => true,
 				'centralauth-usermerge' => true,
-				'oathauth-api-all' => true,
 				'oathauth-enable' => true,
-				'oathauth-disable-for-user' => true,
-				'oathauth-verify-user' => true,
-				'oathauth-view-log' => true,
 			],
 			'user' => [
 				'mwoauthmanagemygrants' => true,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1774,6 +1774,11 @@ $wi->config->settings = [
 				'Repo_Maintainer',
 			],
 		],
+		'simcitywiki' => [
+			'founder' => [
+				'banned',
+			],
+		],
 	],
 	'wgManageWikiPermissionsAdditionalRights' => [
 		'default' => [
@@ -2079,6 +2084,14 @@ $wi->config->settings = [
 				'checkuser-log' => true,
 				'managewiki-restricted' => true,
 				'bigdelete' => true,
+				'userrights' => true,
+				'usermerge' => true,
+				'centralauth-usermerge' => true,
+				'oathauth-api-all' => true,
+				'oathauth-enable' => true,
+				'oathauth-disable-for-user' => true,
+				'oathauth-verify-user' => true,
+				'oathauth-view-log' => true,
 			],
 		],
 		'+sovereignwiki' => [
@@ -2182,6 +2195,11 @@ $wi->config->settings = [
 		'rf1botwiki' => [
 			'bureaucrat' => [
 				'Repo_Maintainer',
+			],
+		],
+		'simcitywiki' => [
+			'founder' => [
+				'banned',
 			],
 		],
 	],
@@ -2525,6 +2543,17 @@ $wi->config->settings = [
 		'ssptopwiki' => [
 			'read-only' => [
 				'edit' => true,
+			],
+		],
+		'simcitywiki' => [
+			'banned' => [
+				'read' => true,
+				'createaccount' => true,
+				'viewmywatchlist' => true,
+				'viewmyprivateinfo' => true,
+				'editmywatchlist' => true,
+				'editmyoptions' => true,
+				'editmyprivateinfo' => true,
 			],
 		],
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2093,6 +2093,8 @@ $wi->config->settings = [
 				'oathauth-verify-user' => true,
 				'oathauth-view-log' => true,
 			],
+			'user' => [],
+			],
 		],
 		'+sovereignwiki' => [
 			'officer' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2093,7 +2093,9 @@ $wi->config->settings = [
 				'oathauth-verify-user' => true,
 				'oathauth-view-log' => true,
 			],
-			'user' => [],
+			'user' => [
+				'mwoauthmanagemygrants' => true,
+			],
 		],
 		'+sovereignwiki' => [
 			'officer' => [


### PR DESCRIPTION
Re-adding a few steward rights that were lost while overriding CU and OS groups

Grant all 2FA-related rights to stewards, just in case

Create banned group to remove read access from registered users (only to be used in extreme cases)