### PR TITLE
Update LocalSettings.php

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -336,7 +336,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'wgCreateWikiBlacklistedSubdomains' => [
-		'default' => '/^(subdomain|.*scratch.*|wiki|www|wikis|misc[0-15]|db[0-15]|cp[0-15]|mw[0-15]|jobrunner[0-15]|gluster[0-15]|ns[0-15]|bacula[0-15]|misc[0-15]|mail[0-15]|mw[0-15]|ldap[0-15]|cloud[0-15]|mon[0-15]|lizardfs[0-15]|rdb[0-15]|phab[0-15]|services[0-15]|puppet[0-15]|test[0-15])+$/',
+		'default' => '/^(subdomain|gazetteer|wikitech|.*scratch.*|wiki|www|wikis|misc[0-15]|db[0-15]|cp[0-15]|mw[0-15]|jobrunner[0-15]|gluster[0-15]|ns[0-15]|bacula[0-15]|misc[0-15]|mail[0-15]|mw[0-15]|ldap[0-15]|cloud[0-15]|mon[0-15]|lizardfs[0-15]|rdb[0-15]|phab[0-15]|services[0-15]|puppet[0-15]|test[0-15])+$/',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',


### PR DESCRIPTION
In the case of "wikitech," per discussion with @RhinosF1 on Discord following a declined wiki creation request. Though we may not need it imminently, it seems prudent to reserve this subdomain for potential Miraheze use as a public or private wiki in the future. Likewise, for "gazetteer," per the several declined wiki requests which @Pix1234 and I have declined, this one seeks to replicate our Gazetteer of Wikis page on Meta without some sort of community discussion and clearly articulating how we could not improve upon the data available in/provided by the WikiDiscover special page. We may want to wildcard "gazetteer" to include "gazeteer" as a misspelling.