### PR TITLE
Switch wgCreateWikiDatabaseClusters to db12 (c3)

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -346,7 +346,7 @@ $wi->config->settings = [
 	],
 	'wgCreateWikiDatabaseClusters' => [
 		'default' => [
-			'c1'
+			'c3'
 		]
 	],
 	'wgCreateWikiGlobalWiki' => [


### PR DESCRIPTION
We're draining db9, so we do not want any new wikis on it.