### PR TITLE
Fix regex for wgCreateWikiBlacklistedSubdomains

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -330,7 +330,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'wgCreateWikiBlacklistedSubdomains' => [
-		'default' => '/^(subdomain|gazetteer|wikitech|.*scratch.*|wiki|www|wikis|misc[0-15]|db[0-15]|cp[0-15]|mw[0-15]|jobrunner[0-15]|gluster[0-15]|ns[0-15]|bacula[0-15]|misc[0-15]|mail[0-15]|mw[0-15]|ldap[0-15]|cloud[0-15]|mon[0-15]|lizardfs[0-15]|rdb[0-15]|phab[0-15]|services[0-15]|puppet[0-15]|test[0-15])+$/',
+		'default' => '/^(subdomain|noc|sandbox[0-15]|outreach|gazetteer|wikitech|.*scratch.*|wiki|www|wikis|misc[0-15]|db[0-15]|cp[0-15]|mw[0-15]|jobrunner[0-15]|gluster[0-15]|ns[0-15]|bacula[0-15]|misc[0-15]|mail[0-15]|mw[0-15]|ldap[0-15]|cloud[0-15]|mon[0-15]|lizardfs[0-15]|rdb[0-15]|phab[0-15]|services[0-15]|puppet[0-15]|test[0-15])+$/',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -330,7 +330,7 @@ $wi->config->settings = [
 
 	// CreateWiki
 	'wgCreateWikiBlacklistedSubdomains' => [
-		'default' => '/^(subdomain|noc|sandbox[0-15]|outreach|gazetteer|wikitech|.*scratch.*|wiki|www|wikis|misc[0-15]|db[0-15]|cp[0-15]|mw[0-15]|jobrunner[0-15]|gluster[0-15]|ns[0-15]|bacula[0-15]|misc[0-15]|mail[0-15]|mw[0-15]|ldap[0-15]|cloud[0-15]|mon[0-15]|lizardfs[0-15]|rdb[0-15]|phab[0-15]|services[0-15]|puppet[0-15]|test[0-15])+$/',
+		'default' => '/^(subdomain|noc|sandbox\d{1,2}|outreach|gazetteer|wikitech|.*scratch.*|wiki|www|wikis|misc\d{1,2}|db\d{1,2}|cp\d{1,2}|mw\d{1,2}|jobrunner\d{1,2}|gluster\d{1,2}|ns\d{1,2}|bacula\d{1,2}|misc\d{1,2}|mail\d{1,2}|mw\d{1,2}|ldap\d{1,2}|cloud\d{1,2}|mon\d{1,2}|lizardfs\d{1,2}|rdb\d{1,2}|phab\d{1,2}|services\d{1,2}|puppet\d{1,2}|test\d{1,2})+$/',
 	],
 	'wgCreateWikiCustomDomainPage' => [
 		'default' => 'Special:MyLanguage/Custom_domains',


### PR DESCRIPTION
Adding "sandbox" to restricted subdomains list because we've had a couple wiki request declines in the past month ([Wiki Request 12598](https://meta.miraheze.org/wiki/Special:RequestWikiQueue/12598) and [Wiki Request 13380](https://meta.miraheze.org/wiki/Special:RequestWikiQueue/13380)), and I don't want to see it inadvertently get created. Also, adding "noc" as a restricted subdomain as I didn't see it in this list, and it's highly conceivable Miraheze may want to use it for technical coordination purposes, either as a wiki or some other website. Finally, though I don't want to create it now, I was talking with @Reception123 on Discord about ways we can (a) increase Meta participation and (b) community volunteerism, and one of the ways in which I think this would be helpful would be through an Outreach wiki, so am requesting we restrict this subdomain for now.

Also, friendly pings @paladox and @RhinosF1, since they were involved in commenting and/or approving/merging my previous pull request.