### PR TITLE
Add 'skipcaptcha' right to sysops on Meta

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2085,6 +2085,7 @@ $wi->config->settings = [
 			],
 			'sysop' => [
 				'interwiki' => true,
+				'skipcaptcha' => true,
 			],
 			'user' => [
 				'requestwiki' => true,


### PR DESCRIPTION
I need this change due to abuse filters and also this is uncontroversial i think