### PR TITLE
add user right to basic grant permissions

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1620,6 +1620,15 @@ $wi->config->settings = [
 		'default' => 'loginwiki',
 	],
 
+	// Grant Permissions for BotPasswords and OAuth
+	'+wgGrantPermissions' => [
+		'default' => [
+			'basic' => [
+				'user' => true,
+			],
+		],
+	],
+
 	//HideSection
 	'wgHideSectionImages' => [
 		'default' => false,


### PR DESCRIPTION
Otherwise bots can't edit pages protected to allow only logged in users if they use BotPasswords or OAuth