### PR TITLE
Update LocalSettings.php to add 'automotive' category to CreateWiki and fix typo in 'eletronics' category

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -460,9 +460,10 @@ $wi->config->settings = [
 	],
 	'wgCreateWikiCategories' => [
 		'default' => [
+			'Automotive' => 'automotive'
 			'Community' => 'community',
 			'Education' => 'education',
-			'Electronics' => 'eletronics',
+			'Electronics' => 'electronics',
 			'Fandom' => 'fandom',
 			'Fantasy' => 'fantasy',
 			'Gaming' => 'gaming',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -460,7 +460,7 @@ $wi->config->settings = [
 	],
 	'wgCreateWikiCategories' => [
 		'default' => [
-			'Automotive' => 'automotive'
+			'Automotive' => 'automotive',
 			'Community' => 'community',
 			'Education' => 'education',
 			'Electronics' => 'electronics',


### PR DESCRIPTION
One of the wiki requests in the queue is categorized as 'electronics'. We don't have any sufficient categories for this type of wiki. Additionally, we have a number of automotive- and automobile-related wikis that could possibly be categorized, if so desired by the local bureaucrats on those wikis, with this added category. Also, fixing a modest typo in 'eletronics' to 'electronics', which likely doesn't require further updates. Pinging @paladox or @NDKilla to see if they can approve and merge. If not, @Reception123 can likely do in the morning when he's awake and caffeinated.