### PR TITLE
Add static.miraheze.org as a default allowed value of $wgTemplateStylesAllowedUrls

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1390,22 +1390,23 @@ $wi->config->settings = [
 
 	// TemplateStyles config
 	'wgTemplateStylesAllowedUrls' => [
-		// Remove when https://gerrit.wikimedia.org/r/486828/ is merged
 		'default' => [
 			'audio' => [
-				'<^(?:https:)?\/\/upload\\.wikimedia\\.org\/wikipedia\/commons\/>',
-				'<^(?:https:)?\/\/static\\.miraheze.org\\.org\/>',
+				'<^(?:https:)?//upload\\.wikimedia\\.org/wikipedia/commons/>',
+				'<^(?:https:)?//static\\.miraheze\\.org/>',
 			],
 			'image' => [
-				'<^(?:https:)?\/\/upload\\.wikimedia\\.org\/wikipedia\/commons\/>',
-				'<^(?:https:)?\/\/static\\.miraheze.org\\.org\/>',
+				'<^(?:https:)?//upload\\.wikimedia\\.org/wikipedia/commons/>',
+				'<^(?:https:)?//static\\.miraheze\\.org/>',
 			],
 			'svg' => [
-				'<^(?:https:)?\/\/upload\\.wikimedia\\.org/wikipedia\/commons\/[^?#]*\\.svg(?:[?#]|$)>',
-				'<^(?:https:)?\/\/static\\.miraheze.org\\.org\/[^?#]*\\.svg(?:[?#]|$)>',
+				'<^(?:https:)?//upload\\.wikimedia\\.org/wikipedia/commons/[^?#]*\\.svg(?:[?#]|$)>',
+				'<^(?:https:)?//static\\.miraheze\\.org/[^?#]*\\.svg(?:[?#]|$)>',
 			],
 			'font' => [],
-			'namespace' => [ '<.>' ],
+			'namespace' => [ 
+				'<.>', 
+			],
 			'css' => [],
 		],
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1394,12 +1394,15 @@ $wi->config->settings = [
 		'default' => [
 			'audio' => [
 				'<^(?:https:)?\/\/upload\\.wikimedia\\.org\/wikipedia\/commons\/>',
+				'<^(?:https:)?\/\/static\\.miraheze.org\\.org\/>',
 			],
 			'image' => [
 				'<^(?:https:)?\/\/upload\\.wikimedia\\.org\/wikipedia\/commons\/>',
+				'<^(?:https:)?\/\/static\\.miraheze.org\\.org\/>',
 			],
 			'svg' => [
 				'<^(?:https:)?\/\/upload\\.wikimedia\\.org/wikipedia\/commons\/[^?#]*\\.svg(?:[?#]|$)>',
+				'<^(?:https:)?\/\/static\\.miraheze.org\\.org\/[^?#]*\\.svg(?:[?#]|$)>',
 			],
 			'font' => [],
 			'namespace' => [ '<.>' ],


### PR DESCRIPTION
This:
* Adds static.miraheze.org as a default allowed value of `$wgTemplateStylesAllowedUrls`.
* Fixes the previous default config for wikimedia, to be back in sync with their configuration, and the default configuration of TemplateStyles.
* Removes the comment, which says to remove that when a patch on Gerrit is merged, this is removed, because that mentioned patch has been abandoned. 