### PR TITLE
Update wgMaxCredits for testwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1612,6 +1612,7 @@ $wi->config->settings = [
 
 	'wgMaxCredits' => [
 		'default' => 0,
+		'+testwiki' => -1,
 	],
 	'wgShowCreditsIfMax' => [
 		'default' => true,


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/Manual:$wgMaxCredits, I'd like to set this function to a negative integer to list all contributors to a given page in the page's footer, for nostalgia and testing purposes. I'm a Consul on TestWiki, so should be fine unless a consensus of other Consuls objects. :P