### PR TITLE
Adding a Language and Linguistics category

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -491,6 +491,7 @@ $wi->config->settings = [
 			'Gaming' => 'gaming',
 			'Geography' => 'geography',
 			'History' => 'history',
+			'Language/Linguistics' => 'langling',
 			'Leisure' => 'leisure',
 			'Literature/Writing' => 'literature',
 			'Media/Journalism' => 'media',


### PR DESCRIPTION
We have a lot of potential, and existing, uses for such a category, such as wikis that propose to teach a language (or language(s)), translation wikis, MediaWiki support wikis in languages in other than English, and dictionary wikis