### PR TITLE
Add Humour/Satire category to CreateWiki/RequestWiki categories

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -496,6 +496,7 @@ $wi->config->settings = [
 			'Gaming' => 'gaming',
 			'Geography' => 'geography',
 			'History' => 'history',
+			'Humour/Satire' => 'humour',
 			'Language/Linguistics' => 'langling',
 			'Leisure' => 'leisure',
 			'Literature/Writing' => 'literature',


### PR DESCRIPTION
Adding much needed humour/satire category to CreateWiki/RequestWiki. Based on the number of approved wikis, and recent requests, I conservatively estimate 100+ existing Miraheze wikis could be recategorised in this way, and expect a minimum of 1 humour/satire wiki request per week will be approved, on average, for the foreseeable future. In short, lots of potential use cases