### PR TITLE
Rename Flow to StructuredDiscussions in ManageWiki, and resort it alp…

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -662,68 +662,6 @@ $wgManageWikiExtensions = [
 				],
 			],
 		],
-		'flow' => [
-			'name' => 'Flow (StructuredDiscussions)',
-			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:StructuredDiscussions',
-			'var' => 'wmgUseFlow',
-			'conflicts' => false,
-			'requires' => [],
-			'help' => 'Will start working 10-20 mins after enabling.',
-			'install' => [
-				'sql' => [
-					'flow_revision' => "$IP/extensions/Flow/flow.sql"
-				],
-				'namespaces' => [
-					'Topic' => [
-						'id' => 2600,
-						'searchable' => 1,
-						'subpages' => 0,
-						'protection' => '',
-						'content' => 0,
-						'aliases' => [],
-						'contentmodel' => 'flow-board',
-						'additional' => []
-					],
-					'Topic_talk' => [
-						'id' => 2601,
-						'searchable' => 0,
-						'subpages' => 0,
-						'protection' => '',
-						'content' => 0,
-						'aliases' => [],
-						'contentmodel' => 'wikitext',
-						'additional' => []
-					],
-				],
-				'permissions' => [
-					'*' => [
-						'permissions' => [
-							'flow-hide',
-						],
-					],
-					'user' => [
-						'permissions' => [
-							'flow-lock',
-						],
-					],
-					'sysop' => [
-						'permissions' => [
-							'flow-lock',
-							'flow-delete',
-							'flow-edit-post',
-						],
-					],
-					'flow-bot' => [
-						'permissions' => [
-							'flow-create-board',
-						],
-					],
-				],
-				'mwscript' => [
- 					"$IP/extensions/Flow/maintenance/FlowCreateTemplates.php" => [],
-				],
-			],
-		],
 		'foreground' => [
 			'name' => 'Foreground (Skin)',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Skin:Foreground',
@@ -1882,6 +1820,68 @@ $wgManageWikiExtensions = [
 			'var' => 'wmgUseStopForumSpam',
 			'conflicts' => false,
 			'requires' => [],
+		],
+		'flow' => [
+			'name' => 'StructuredDiscussions (Flow)',
+			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:StructuredDiscussions',
+			'var' => 'wmgUseFlow',
+			'conflicts' => false,
+			'requires' => [],
+			'help' => 'Will start working 10-20 mins after enabling.',
+			'install' => [
+				'sql' => [
+					'flow_revision' => "$IP/extensions/Flow/flow.sql"
+				],
+				'namespaces' => [
+					'Topic' => [
+						'id' => 2600,
+						'searchable' => 1,
+						'subpages' => 0,
+						'protection' => '',
+						'content' => 0,
+						'aliases' => [],
+						'contentmodel' => 'flow-board',
+						'additional' => []
+					],
+					'Topic_talk' => [
+						'id' => 2601,
+						'searchable' => 0,
+						'subpages' => 0,
+						'protection' => '',
+						'content' => 0,
+						'aliases' => [],
+						'contentmodel' => 'wikitext',
+						'additional' => []
+					],
+				],
+				'permissions' => [
+					'*' => [
+						'permissions' => [
+							'flow-hide',
+						],
+					],
+					'user' => [
+						'permissions' => [
+							'flow-lock',
+						],
+					],
+					'sysop' => [
+						'permissions' => [
+							'flow-lock',
+							'flow-delete',
+							'flow-edit-post',
+						],
+					],
+					'flow-bot' => [
+						'permissions' => [
+							'flow-create-board',
+						],
+					],
+				],
+				'mwscript' => [
+ 					"$IP/extensions/Flow/maintenance/FlowCreateTemplates.php" => [],
+				],
+			],
 		],
 		'subpagefun' => [
 			'name' => 'SubPageFun',


### PR DESCRIPTION
…habetically in the ManageWiki extensions list

Per this request on Discord (https://discord.com/channels/407504499280707585/407537962553966603/763915864353275916), users are having some difficulty locating StructuredDiscussions in Special:ManageWiki/Extensions, since we've renamed it to its new name everywhere else on-wiki, the Extensions page, the Miraheze page, and even in ManageWiki itself. Former name should go in parentheses. I don't appear to be changing any database IDs, so likely no database changes are needed