### PR TITLE
Enable tabular.JsonConfigs per T6214

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3919,6 +3919,62 @@ if ( $wgDBname !== 'commonswiki' && $wgMirahezeCommons ) {
 	];
 }
 
+// JsonConfig Extension
+if ( $wmgEnableJsonConfigDataMode ) {
+	// Safety: before extension.json, these values were initialized by JsonConfig.php
+	if ( !isset( $wgJsonConfigModels ) ) {
+		$wgJsonConfigModels = [];
+	}
+	if ( !isset( $wgJsonConfigs ) ) {
+		$wgJsonConfigs = [];
+	}
+
+	$wgJsonConfigEnableLuaSupport = true;
+
+	// https://www.mediawiki.org/wiki/Extension:JsonConfig#Configuration
+
+	$wgJsonConfigModels['Tabular.JsonConfig'] = 'JsonConfig\JCTabularContent';
+	$wgJsonConfigs['Tabular.JsonConfig'] = [
+		'namespace' => 486,
+		'nsName' => 'Data',
+		// page name must end in ".tab", and contain at least one symbol
+		'pattern' => '/.\.tab$/',
+		'license' => 'CC0-1.0',
+		'isLocal' => false,
+	];
+
+	$wgJsonConfigModels['Map.JsonConfig'] = 'JsonConfig\JCMapDataContent';
+	$wgJsonConfigs['Map.JsonConfig'] = [
+		'namespace' => 486,
+		'nsName' => 'Data',
+		// page name must end in ".map", and contain at least one symbol
+		'pattern' => '/.\.map$/',
+		'license' => 'CC0-1.0',
+		'isLocal' => false,
+	];
+
+	// Enable Tabular data namespace on Commons
+	// Enable Map (GeoJSON) data namespace on Commons 
+	// TODO: Consider whether this hard-coding to Commons is appropriate
+	if ( $wgDBname === 'commonswiki' ) {
+		// Ensure we have a stable cross-wiki title resolution
+		// See JCSingleton::parseTitle()
+		$wgJsonConfigInterwikiPrefix = "meta";
+
+		$wgJsonConfigs['Tabular.JsonConfig']['store'] = true;
+		$wgJsonConfigs['Map.JsonConfig']['store'] = true;
+	} else {
+		$wgJsonConfigInterwikiPrefix = "commons";
+
+		$wgJsonConfigs['Tabular.JsonConfig']['remote'] = [
+			'url' => 'https://commons.miraheze.org/w/api.php'
+		];
+		$wgJsonConfigs['Map.JsonConfig']['remote'] = [
+			'url' => 'https://commons.miraheze.org/w/api.php'
+		];
+	}
+}
+
 // When using ?forceprofile=1, a profile can be found as an HTML comment
 // Disabled on production hosts because it seems to be causing performance issues (how ironic)
 if (


### PR DESCRIPTION
For the Spanish Wikipedia [ Extract template](https://es.wikipedia.org/wiki/Plantilla:Extracto) to work, see an example of an error in https://hispano76.miraheze.org/wiki/Usuario:Hispano76/Pruebas

On commons.miraheze.org, the _486/Data_ namespace been created. And bug fix.. MWUnknownContentModelException: https://commons.miraheze.org/wiki/Data:I18n/Module:Excerpt.tab

https://phabricator.miraheze.org/T6214