### PR TITLE
Remove CrossReference

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -255,10 +255,6 @@ if ( $wmgUseCreateRedirect ) {
 	wfLoadExtension( 'CreateRedirect' );
 }
 
-if ( $wmgUseCrossReference ) {
-	wfLoadExtension( 'CrossReference' );
-}
-
 if ( $wmgUseCSS ) {
 	wfLoadExtension( 'CSS' );
 }

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -465,13 +465,6 @@ $wgManageWikiExtensions = [
 			'conflicts' => false,
 			'requires' => [],
 		],
-		'crossreference' => [
-			'name' => 'CrossReference',
-			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:CrossReference',
-			'var' => 'wmgUseCrossReference',
-			'conflicts' => false,
-			'requires' => [],
-		],
 		'css' => [
 			'name' => 'CSS',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:CSS',

--- a/extension-list
+++ b/extension-list
@@ -45,7 +45,6 @@ $IP/extensions/CreatePage/CreatePage.php
 $IP/extensions/CreatePageUw/extension.json
 $IP/extensions/CreateRedirect/extension.json
 $IP/extensions/CreateWiki/extension.json
-$IP/extensions/CrossReference/extension.json
 $IP/extensions/DarkMode/extension.json
 $IP/extensions/DataDump/extension.json
 $IP/extensions/DataTransfer/extension.json


### PR DESCRIPTION
Extension not supported by 1.35 and also extension is severally unmaintained.