### PR TITLE
$wmgFederatedPropertiesEnabled default to false

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3766,7 +3766,7 @@ $wi->config->settings = [
 		'default' => true,
 	],
 	'wmgFederatedPropertiesEnabled' => [
-		'default' => true,
+		'default' => false,
 	],
 	'wmgWikibaseRepoUrl' => [
 		'default' => 'https://wikidata.org'

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1966,7 +1966,7 @@ $wgManageWikiSettings = [
 		'restricted' => false,
 		'from' => 'wikibaserepository',
 		'type' => 'check',
-		'overridedefault' => true,
+		'overridedefault' => false,
 		'section' => 'wikibase',
 		'help' => 'To determine if federated properties should be enabled or not.',
 	],


### PR DESCRIPTION
`$wmgFederatedPropertiesEnabled` should default to false, as that is the default Wikibase configuration value.