### PR TITLE
Also install tables-generated.sql for new wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -453,6 +453,7 @@ $wi->config->settings = [
 	'wgCreateWikiSQLfiles' => [
 		'default' => [
 			"$IP/maintenance/tables.sql",
+			"$IP/maintenance/tables-generated.sql",
 			"$IP/extensions/AbuseFilter/abusefilter.tables.sql",
 			"$IP/extensions/AntiSpoof/sql/patch-antispoof.mysql.sql",
 			"$IP/extensions/BetaFeatures/sql/create_counts.sql",


### PR DESCRIPTION
Actor and a few other tables were put into tables-generated.sql, it seems to be because of the new abstract schema system.