### PR TITLE
Stop logging redis things

### DIFF
--- a/GlobalLogging.php
+++ b/GlobalLogging.php
@@ -73,7 +73,7 @@ if ( wfHostname() === 'test2' ) {
 		'MatomoAnalytics' => "$wmgLogDir/debuglogs/MatomoAnalytics.log",
 		'ManageWiki' => "$wmgLogDir/debuglogs/ManageWiki.log",
 		'OAuth' => "$wmgLogDir/debuglogs/OAuth.log",
-		'redis' => "$wmgLogDir/debuglogs/redis.log",
+		// 'redis' => "$wmgLogDir/debuglogs/redis.log",
 		'spf-tmp' => "$wmgLogDir/debuglogs/spf-tmp.log",
 		'thumbnail' => "$wmgLogDir/debuglogs/thumbnail.log",
 		'VisualEditor' => "$wmgLogDir/debuglogs/VisualEditor.log",


### PR DESCRIPTION
It appears since the upgrade to 1.35, it's causing a load of spam to hit the redis log with stuff like "worthRefreshPopular(1604102439.6853, 60, 900, 1604104011.4142): p = 0.0012121212121212; refresh = N"

causing the log to go >2gb