### PR TITLE
Remove deleted wikis

### DIFF
--- a/ContactPage.php
+++ b/ContactPage.php
@@ -1,50 +1,5 @@
 <?php
 
-if ( $wgDBname == 'apellidosmurcianoswiki' ) {
-	$wgContactConfig['default'] = [
-		'RecipientUser' => 'Lorenzolaxmonzon',
-		'SenderEmail' => $wgPasswordSender,
-		'SenderName' => 'Miraheze No Reply',
-		'RequireDetails' => true,
-		'IncludeIP' => false, // No privy
-		'MustBeLoggedIn' => false,
-		'AdditionalFields' => [],
-		'DisplayFormat' => 'table',
-		'RLModules' => [],
-		'RLStyleModules' => [],
-	];
-}
-
-if ( $wgDBname == 'ayrshirewiki' ) {
-	$wgContactConfig['default'] = [
-		'RecipientUser' => 'Gordonuk',
-		'SenderEmail' => $wgPasswordSender,
-		'SenderName' => 'Miraheze No Reply',
-		'RequireDetails' => true,
-		'IncludeIP' => false, // No privy
-		'MustBeLoggedIn' => false,
-		'AdditionalFields' => [],
-		'DisplayFormat' => 'table',
-		'RLModules' => [],
-		'RLStyleModules' => [],
-	];
-}
-
-if ( $wgDBname == 'cdcwiki' ) {
-	$wgContactConfig['default'] = [
-		'RecipientUser' => 'NonstickRon',
-		'SenderEmail' => $wgPasswordSender,
-		'SenderName' => 'Miraheze No Reply',
-		'RequireDetails' => true,
-		'IncludeIP' => false, // Lets not do this ever for privacy (unless offical forms)
-		'MustBeLoggedIn' => false,
-		'AdditionalFields' => [],
-		'DisplayFormat' => 'table',
-		'RLModules' => [],
-		'RLStyleModules' => [],
-	];
-}
-
 if ( $wgDBname == 'christipediawiki' ) {
 	$wgContactConfig['default'] = [
 		'RecipientUser' => 'Kees Langeveld',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2152,31 +2152,6 @@ $wi->config->settings = [
 				'read' => true,
 			],
 		],
-		'+cyclonepediawiki' => [
-			'bureaucrat' => [
-				'bureaucrat' => true,
-			],
-			'extendedconfirmed' => [
-				'extendedconfirmed' => true,
-			],
-			'sysop' => [
-				'extendedconfirmed' => true,
-			],
-		],
-		'+dpwiki' => [
-			'bureaucrat' => [
-				'bureaucrat' => true,
-				'respected' => true,
-			],
-			'respected' => [
-				'respected' => true,
-			],
-		],
-		'+enigmawiki' => [
-			'scribe' => [
-				'read' => true,
-			],
-		],
 		'+hypopediawiki' => [
 			'bureaucrat' => [
 				'bureaucrat' => true,
@@ -2246,40 +2221,9 @@ $wi->config->settings = [
 				'read' => true,
 			],
 		],
-		'+jayuwikiwiki' => [
-			'sysop' => [
-				'editvoter' => true,
-			],
-			'voter' => [
-				'editvoter' => true,
-			],
-		],
-		'+lcars47wiki' => [
-			'bureaucrat' => [
-				'bureaucrat' => true,
-			],
-			'devteam' => [
-				'bureaucrat' => true,
-				'read' => true,
-				'devteam' => true,
-			],
-		],
 		'+ldapwikiwiki' => [
 			'sysop' => [
 				'managewiki-restricted' => true,
-			],
-		],
-		'+marthaspeakswiki' => [
-			'sysop' => [
-				'templateeditor' => true,
-			],
-			'templateeditor' => [
-				'templateeditor' => true,
-			],
-		],
-		'+nenawikiwiki' => [
-			'emailconfirmed' => [
-				'read' => true,
 			],
 		],
 		'+metawiki' => [
@@ -2325,6 +2269,9 @@ $wi->config->settings = [
 				'edit-content-pages' => true,
 				'edit-talkpage' => true,
 			],
+			'emailconfirmed' => [
+				'read' => true,
+			],
 			'nenamembers' => [
 				'edit-talkpage' => true,
 			],
@@ -2351,30 +2298,9 @@ $wi->config->settings = [
 				'editstaffprotected' => true,
 			],
 		],
-		'+radviserwiki' => [
-			'editor' => [
-				'editor' => true,
-			],
-			'sysop' => [
-				'editor' => true,
-			],
-		],
 		'+rf1botwiki' => [
 			'Repo_Maintainer' => [
 				'editrepos' => true,
-			],
-		],
-		'+sau226wiki' => [
-			'bureaucrat' => [
-				'bureaucrat' => true,
-			],
-			'consul' => [
-				'bureaucrat' => true,
-				'consul' => true,
-				'read' => true,
-			],
-			'testgroup' => [
-				'read' => true,
 			],
 		],
 		'+sesupportwiki' => [
@@ -2383,17 +2309,6 @@ $wi->config->settings = [
 			],
 			'sysop' => [
 				'editor' => true,
-			],
-		],
-		'+serinfhospwiki' => [
-			'SupportStaff' => [
-				'read' => true,
-			],
-			'SalesStaff' => [
-				'read' => true,
-			],
-			'PreSalesStaff' => [
-				'read' => true,
 			],
 		],
 		'simcitywiki' => [
@@ -2422,39 +2337,6 @@ $wi->config->settings = [
 				'mwoauthmanagemygrants' => true,
 			],
 		],
-		'+sovereignwiki' => [
-			'officer' => [
-				'read' => true,
-				'officer' => true,
-			],
-			'game-master' => [
-				'read' => true,
-				'game-master' => true,
-			],
-		],
-		'+ssptopwiki' => [
-			'read-only' => [
-				'read' => true,
-			],
-		],
-		'+swisscomraidwiki' => [
-			'emailconfirmed' => [
-				'read' => true,
-			],
-		],
-		'+svwiki' => [
-			'bureaucrat' => [
-				'bureaucrat' => true,
-			],
-			'consul' => [
-				'bureaucrat' => true,
-				'consul' => true,
-				'read' => true,
-			],
-			'testgroup' => [
-				'read' => true,
-			],
-		],
 		'+testwiki' => [
 			'consul' => [
 				'consul' => true,
@@ -2472,31 +2354,18 @@ $wi->config->settings = [
 				'templateeditor' => true,
 			],
 		],
-		'+trexwiki' => [
-			'co' => [
-				'co' => true,
-				'ceo' => true,
-			],
-			'ceo' => [
-				'ceo' => true,
-				'editors' => true,
-			],
-			'bureaucrat' => [
-				'bureaucrat' => true,
-			],
-		],
 		'+vnenderbotwiki' => [
 			'templateeditor' => [
-					     'template' => true,
+					  'template' => true,
 			],
 			'extendedconfirmed' => [
-					        'extendedconfirmed' => true,
+					     'extendedconfirmed' => true,
 			],
 			'Owner' => [
-				   'template' => true,
-				   'extendedconfirmed' => true,
-				   'owner' => true,
-				],
+				'template' => true,
+				'extendedconfirmed' => true,
+				'owner' => true,
+			],
 		],
 		'+whentheycrywiki' => [
 			'user' => [
@@ -2507,14 +2376,9 @@ $wi->config->settings = [
 			'consul' => [
 				'consul' => true,
 				'bureaucrat' => true,
-				],
+			],
 			'bureaucrat' => [
 				'bureaucrat' => true,
-				],
-		],
-		'+yeoksawiki' => [
-			'sysop' => [
-				'project-edit' => true,
 			],
 		],
 	],
@@ -3127,14 +2991,6 @@ $wi->config->settings = [
 			'sysop',
 			'pm',
 			'member',
-		],
-		'+cyclonepediawiki' => [
-			'bureaucrat',
-			'extendedconfirmed',
-		],
-		'+dpwiki' => [
-			'bureaucrat',
-			'respected',
 		],
 		'+hypopediawiki' => [
 			'bureaucrat',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -132,7 +132,7 @@ $wi->config->settings = [
 			'useAddThisShare' => '',
 			'useAddThisFollow' => ''
 		],
-		'thegreatwarwiki' => [
+		'+thegreatwarwiki' => [
 			'showActionsForAnon' => true,
 			'fixedNavBar' => true,
 			'usePivotTabs' => true,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2795,11 +2795,6 @@ $wi->config->settings = [
 	],
 	'wgRevokePermissions' => [
 		'default' => [],
-		'ssptopwiki' => [
-			'read-only' => [
-				'edit' => true,
-			],
-		],
 		'simcitywiki' => [
 			'banned' => [
 				'read' => true,
@@ -3010,32 +3005,15 @@ $wi->config->settings = [
 			'sysmag',
 			'trusted',
 		],
-		'+lcars47wiki' => [
-			'bureaucrat',
-			'devteam',
-		],
-		'+marthaspeakswiki' => [
-			'templateeditor',
-		],
 		'+quircwiki' => [
 			'editstaffprotected',
 		],
 		'+rf1botwiki' => [
 			'editrepos',
 		],
-		'+sau226wiki' => [
-			'bureaucrat',
-			'consul',
-		],
-		'+jayuwikiwiki' => [
-			'editvoter',
-		],
 		'+pruebawiki' => [
 			'bureaucrat',
 			'consul',
-		],
-		'+radviserwiki' => [
-			'editor',
 		],
 		'+sesupportwiki' => [
 			'editor',
@@ -3043,10 +3021,6 @@ $wi->config->settings = [
 		'simcitywiki' => [
 			'autoconfirmed',
 			'sysop',
-		],
-		'+sovereignwiki' => [
-			'officer',
-			'game-master',
 		],
 		'+studynotekrwiki' => [
 			'voter',
@@ -3057,12 +3031,6 @@ $wi->config->settings = [
 		],
 		'+thesciencearchiveswiki' => [
 			'templateeditor',
-		],
-		'+trexwiki' => [
-			'sysmag',
-			'bureaucrat',
-			'ceo',
-			'co',
 		],
 		'+vnenderbotwiki' => [
 			'template',
@@ -3310,26 +3278,6 @@ $wi->config->settings = [
 			'poll_vote' => 0,
 			'quiz_points' => 0,
 			'quiz_created' => 0,
-		],
-		'uncyclopedia2wiki' => [
-			'edit' => 50,
-			'vote' => 10,
-			'comment' => 0,
-			'comment_plus' => 40,
-			'comment_ignored' => -10,
-			'opinions_created' => 0,
-			'opinions_pub' => 10,
-			'referral_complete' => 0,
-			'friend' => 100,
-			'foe' => 0,
-			'gift_rec' => 25,
-			'gift_sent' => 10,
-			'points_winner_weekly' => 0,
-			'points_winner_monthly' => 0,
-			'user_image' => 1000,
-			'poll_vote' => 10,
-			'quiz_points' => 50,
-			'quiz_created' => 20,
 		],
 	],
 	'wgFriendingEnabled' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -117,13 +117,35 @@ $wi->config->settings = [
 		'default' => false,
 	],
 	'wgPivotFeatures' => [
+		'default' => [
+			'showActionsForAnon' => true,
+			'fixedNavBar' => false,
+			'usePivotTabs' => false,
+			'showHelpUnderTools' => true,
+			'showRecentChangesUnderTools' => true,
+			'wikiName' => $wgSitename,
+			'wikiNameDesktop' => $wgSitename,
+			'navbarIcon' => false,
+			'preloadFontAwesome' => false,
+			'showFooterIcons' => true,
+			'addThisPUBID' => '',
+			'useAddThisShare' => '',
+			'useAddThisFollow' => ''
+		],
 		'thegreatwarwiki' => [
-			'usePivotTabs' => true,
+			'showActionsForAnon' => true,
 			'fixedNavBar' => true,
+			'usePivotTabs' => true,
 			'showHelpUnderTools' => false,
 			'showRecentChangesUnderTools' => false,
+			'wikiName' => $wgSitename,
 			'wikiNameDesktop' => 'The Great War 1914-1918',
-			'showFooterIcons' => true
+			'navbarIcon' => false,
+			'preloadFontAwesome' => false,
+			'showFooterIcons' => true,
+			'addThisPUBID' => '',
+			'useAddThisShare' => '',
+			'useAddThisFollow' => ''
 		],
 	],
 
@@ -318,7 +340,6 @@ $wi->config->settings = [
 	// Category
 	'wgUseCategoryBrowser' => [
 		'default' => false,
-		'modesofdiscoursewiki' => true,
 	],
 
 	'wgCategoryPagingLimit' => [
@@ -328,7 +349,10 @@ $wi->config->settings = [
 
 	// CentralAuth
 	'wgCentralAuthAutoCreateWikis' => [
-		'default' => [ 'loginwiki', 'metawiki' ],
+		'default' => [ 
+			'loginwiki', 
+			'metawiki' 
+		],
 	],
 	'wgCentralAuthAutoNew' => [
 		'default' => true,
@@ -1961,7 +1985,6 @@ $wi->config->settings = [
 	'wgRightsPage' => [
 		'default' => '',
 		'diavwiki' => 'Project:Copyrights',
-		'kstartupswiki' => 'Project:저작권',
 		'wisdomwikiwiki' => 'Copyleft',
 	],
 	'wgRightsText' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -566,19 +566,16 @@ $wi->config->settings = [
 	],
 	'wgCompressRevisions' => [
 		'default' => false,
-		'absurdopediawiki' => true,
 		'allthetropeswiki' => true,
 		'altversewiki' => true,
 		'americangirldollswiki' => true,
-		'animatedfeetwiki' => true,
 		'animebathswiki' => true,
-		'baobabarchiveswiki' => true,
 		'beidipediawiki' => true,
 		'buswiki' => true,
 		'commonwealthwiki' => true,
 		'crappygameswiki' => true,
-		'crystalmaidenswiki' => true,
 		'cwarswiki' => true,
+		'drawnfeetwiki' => true,
 		'evilbabeswiki' => true,
 		'incubatorwiki' => true,
 		'libertygamewiki' => true,
@@ -591,9 +588,7 @@ $wi->config->settings = [
 		'simswiki' => true,
 		'thelastsovereignwiki' => true,
 		'tmewiki' => true,
-		'toxicfandomsandhatedomswiki' => true,
-		'trollpastawiki' => true,
-		'trollpastauncensoredwiki' => true,
+		'toxicfandomsandhatedomswiki' => true, // locked wiki
 		'uncyclomirrorwiki' => true,
 		'ungamewiki' => true,
 	],
@@ -843,10 +838,7 @@ $wi->config->settings = [
 	],
 	'wmgUseContactPage' => [
 		'default' => false, // Add wiki config to ContactPage.php
-		'apellidosmurcianoswiki' => true,
-		'ayrshirewiki' => true,
 		'christipediawiki' => true,
-		'cdcwiki' => true,
 		'guiaslocaiswiki' => true,
 		'test2wiki' => true,
 	],
@@ -1491,6 +1483,14 @@ $wi->config->settings = [
 		'default' => false,
 	],
 	'egApprovedRevsEnabledNamespaces' => [
+ 		'default' => [
+			NS_MAIN => true,
+			NS_USER => true,
+ 			NS_FILE => true,
+			NS_TEMPLATE => true,
+			NS_HELP => true,
+			NS_PROJECT => true
+		],
  		'valkyrienskieswiki' => [
 			NS_MAIN => false,
 			NS_USER => false,
@@ -1818,11 +1818,6 @@ $wi->config->settings = [
 	// HideSection
 	'wgHideSectionImages' => [
 		'default' => false,
-		'cikansaiwiki' => [
-			'show' => 'https://static.miraheze.org/cikansaiwiki/4/43/HideSectionDOWN.png',
-			'hide' => 'https://static.miraheze.org/cikansaiwiki/b/bd/HideSectionUP.png',
-			'location' => 'end'
-		],
 	],
 	// HighlightLinks
 	'wgHighlightLinksInCategory' => [
@@ -2013,7 +2008,6 @@ $wi->config->settings = [
 	'+wgUrlProtocols' => [
 		'default' => [],
 		// file protocol only allowed on private wikis
-		'bchwiki' => [ "file://" ],
 		'gzewiki' => [ "file://" ],
 		'kaiwiki' => [ "file://" ],
 		'vtwiki' => [ "discord://" ],
@@ -2725,9 +2719,6 @@ $wi->config->settings = [
 	// MobileFrontend
 	'wgMFNoMobilePages' => [
 		'default' => [],
-		'alwikiwiki' => [
-			'Main Page',
-		],
 	],
 	// Math
 	'wgMathoidCli' => [
@@ -2997,14 +2988,6 @@ $wi->config->settings = [
 			'ceo',
 			'co',
 		],
-		'+kyivstarwiki' => [
-			'co',
-			'ceo',
-			'editor',
-			'extendedconfirmed',
-			'sysmag',
-			'trusted',
-		],
 		'+quircwiki' => [
 			'editstaffprotected',
 		],
@@ -3021,9 +3004,6 @@ $wi->config->settings = [
 		'simcitywiki' => [
 			'autoconfirmed',
 			'sysop',
-		],
-		'+studynotekrwiki' => [
-			'voter',
 		],
 		'+testwiki' => [
 			'bureaucrat',
@@ -3292,9 +3272,8 @@ $wi->config->settings = [
 		'gfiwiki' => 'any',
 		'hispanowiki' => 'any',
 		'hispano76wiki' => 'any',
-		'hrfwiki2' => 'any',
+		'hrfwiki2wiki' => 'any',
 		'ildrilwiki' => 'any',
-		'lothuialethwiki' => 'any',
 		'nonciclopediawiki' => 'any',
 		'privadowiki' => 'any',
 		'simswiki' => 'any',
@@ -3449,7 +3428,6 @@ $wi->config->settings = [
 			'(.*\.)?miraheze\.org',
 			'adadevelopersacademy\.wiki',
 			'allthetropes\.org',
-			'aman\.info\.tm',
 			'antiguabarbudacalypso\.com',
 			'astrapedia\.ru',
 			'athenapedia\.org',
@@ -3595,8 +3573,7 @@ $wi->config->settings = [
 		'default' => false,
 	],
 	'wgVisualEditorEnableVisualSectionEditing' => [
-		'default' => false,
-		'dcmultiversewiki' => 'mobile',
+		'default' => 'mobile',
 	],
 
 	// Protect site config

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -120,10 +120,6 @@ if ( $wmgPrivateUploads ) {
 	$wi->config->settings['wgGenerateThumbnailOnParse']['default'] = true;
 }
 
-if ( $wgDBname === 'hamzawiki' ) {
-	 $wgWhitelistRead[] = 'Rukus';
-}
-
 if ( $wgDBname === 'isvwiki' ) {
 	$wgExtraLanguageNames['isv'] = 'Medžuslovjansky';
 	$wgExtraInterlanguageLinkPrefixes = [ 'd' ];
@@ -193,19 +189,10 @@ if ( $wgDBname === 'swiki' ) {
 	 $wgWhitelistRead[] = 'メインページ/ja';
 }
 
-if ( $wgDBname === 'swisscomraidwiki' ) {
-	$wgAutopromote['emailconfirmed'] = APCOND_EMAILCONFIRMED;
-}
-
 if ( $wgDBname === 'simcitywiki' ) {
 	unset( $wgGroupPermissions['oversight'] );
 	unset( $wgGroupPermissions['interwiki-admin'] );
 	unset( $wgGroupPermissions['checkuser'] );
-}
-
-// Depends on $wgContentNamespaces
-if ( $wgDBname === 'abitaregeawiki' ) {
-	$wi->config->settings['wgExemptFromUserRobotsControl']['default'] = [];
 }
 
 // Licensing variables
@@ -271,17 +258,8 @@ switch ( $wmgWikiLicense ) {
 
 if ( $wgDBname === 'gyaanipediawiki' ||
 	 $wgDBname === 'higyaanipediawiki' ||
-	 $wgDBname === 'bngyaanipediawiki' ||
-	 $wgDBname === 'tegyaanipediawiki' ||
-	 $wgDBname === 'tagyaanipediawiki' ||
 	 $wgDBname === 'mrgyaanipediawiki' ||
-	 $wgDBname === 'gugyaanipediawiki' ||
-	 $wgDBname === 'pagyaanipediawiki' ||
-	 $wgDBname === 'kngyaanipediawiki' ||
-	 $wgDBname === 'maigyaanipediawiki' ||
-	 $wgDBname === 'bhgyaanipediawiki' ||
-	 $wgDBname === 'asgyaanipediawiki' ||
-	 $wgDBname === 'mlgyaanipediawiki'
+	 $wgDBname === 'pagyaanipediawiki'
 ) {
 	// per Ucronistaw
 	$wgForeignFileRepos[] = [


### PR DESCRIPTION
Removes configurstion for deleted wikis, from the files, ContactPage.php, LocalSettings.php, and LocalWiki.php
Also:
* Fixes database name for `hrfwiki2wiki`, which was previously set as `hrfwiki2`
* Cleans up formatting
* Sets default for `$egApprovedRevsEnabledNamespaces` and `$wgPivotFeatures`
* Changes default for `$wgVisualEditorEnableVisualSectionEditing` to `mobile` (https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/9f9966d1cda186086f74c8d810b081b4d189fe8c/extension.json#L93)