### PR TITLE
Remove FlaggedRevsRestrictionLevels from ManageWikiSettings

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -175,21 +175,6 @@ $wgManageWikiSettings = [
 		'section' => 'anti-spam',
 		'help' => 'Auto-review settings for edits/new pages.',
 	],
-	'wmgFlaggedRevsRestrictionLevels' => [
-		'name' => 'FlaggedRevs Restriction Levels',
-		'from' => 'flaggedrevs',
-		'restricted' => false,
-		'type' => 'usergroups',
-		'options' => [
-			'No Restriction' => '',
-		],
-		'overridedefault' => [
-			'',
-			'sysop',
-		],
-		'section' => 'anti-spam',
-		'help' => 'Restriction levels for "autoreview"/"review" rights.',
-	],
 	'wmgSimpleFlaggedRevsUI' => [
 		'name' => 'Simple FlaggedRevs UI',
 		'from' => 'flaggedrevs',


### PR DESCRIPTION
Removing `$wmgFlaggedRevsRestrictionLevels` as it's not actually supported by ManageWiki for the same reason `$wgRestrictionLevels` is not. It uses user rights, not user groups. https://github.com/wikimedia/mediawiki-extensions-FlaggedRevs/blob/5904212d4ec3cb3a56b8bb493b8ba57f644f628e/backend/FlaggedRevs.php#L478