### PR TITLE
Remove Extension:Bootstrap from ManageWikiExtensions

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -99,10 +99,6 @@ if ( $wmgUseBlogPage ) {
 	$wgBlogPageDisplay['comments_of_day'] = false;
 }
 
-if ( $wmgUseBootstrap ) {
-	wfLoadExtension( 'Bootstrap' );
-};
-
 if ( $wmgUseMSCalendar ) {
 	wfLoadExtension( 'MsCalendar' );
 }

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -800,9 +800,6 @@ $wi->config->settings = [
 	'wmgUseBabel' => [
 		'default' => false,
 	],
-	'wmgUseBootstrap' => [
-		'default' => false,
-	],
 	'wmgUseMSCalendar' => [
 		'default' => false,
 	],

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -241,13 +241,6 @@ $wgManageWikiExtensions = [
 				],
 			],
 		],
-		'Bootstrap' => [
-			'name' => 'Bootstrap',
-			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Bootstrap',
-			'var' => 'wmgUseBootstrap',
-			'conflicts' => false,
-			'requires' => [],
-		],
 		'calendar-wikivoyage' => [
 			'name' => 'Calendar-Wikivoyage',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Calendar-Wikivoyage',

--- a/extension-list
+++ b/extension-list
@@ -14,7 +14,6 @@ $IP/extensions/AutoCreatePage/AutoCreatePage.php
 $IP/extensions/Babel/extension.json
 $IP/extensions/BetaFeatures/extension.json
 $IP/extensions/BlogPage/extension.json
-$IP/extensions/Bootstrap/extension.json
 $IP/extensions/CSS/extension.json
 $IP/extensions/Calendar/extension.json
 $IP/extensions/Cargo/extension.json

--- a/extension-list
+++ b/extension-list
@@ -14,6 +14,7 @@ $IP/extensions/AutoCreatePage/AutoCreatePage.php
 $IP/extensions/Babel/extension.json
 $IP/extensions/BetaFeatures/extension.json
 $IP/extensions/BlogPage/extension.json
+$IP/extensions/Bootstrap/extension.json
 $IP/extensions/CSS/extension.json
 $IP/extensions/Calendar/extension.json
 $IP/extensions/Cargo/extension.json


### PR DESCRIPTION
Extension:Bootstrap is only useful for Skin:Chameleon. If we ever end up installing that, then this extension can just be enabled with it, not through MWE as that gets confusing. https://phabricator.miraheze.org/T2841#65856