### PR TITLE
Adding `simple` interlanguage prefix to TestWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1878,6 +1878,9 @@ $wi->config->settings = [
 			'v',
 			'n',
 		],
+		'+testwiki' => [
+			'simple',
+		],
 		'+ucroniaswiki' => [
 			'h',
 			'w',


### PR DESCRIPTION
If the test is successful, I will propose a second PR for @Reception123 to review that will add `simple` to the default setting