### PR TITLE
Add simple interlanguage prefix to default

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1856,7 +1856,9 @@ $wi->config->settings = [
 		'default' => 'metawiki',
 	],
 	'wgExtraInterlanguageLinkPrefixes' => [
-		'default' => [],
+		'default' => [
+			'simple',	
+		],
 		'+nonciclopediawiki' => [
 			'dlm',
 			'olb',


### PR DESCRIPTION
Following this successful test PR (https://github.com/miraheze/mw-config/pull/3383) and test (https://publictestwiki.com/wiki/Special:Log/interwiki), we are now good to add `simple` as an interlanguage prefix across all interwiki tables