### PR TITLE
Remove visualeditor-enable from defaultuseroptions

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2941,7 +2941,6 @@ $wi->config->settings = [
 		'+dcmultiversewiki' => [
 			'usecodemirror' => 1,
 			'visualeditor-newwikitext' => 1,
-			'visualeditor-enable' => 1,
 			'usebetatoolbar' => 0,
 			'usebetatoolbar-cgd' => 0,
 			'visualeditor-enable-experimental' => 1,
@@ -2960,7 +2959,6 @@ $wi->config->settings = [
 		],
 		'+yablestudiowiki' => [
 			'visualeditor-newwikitext' => 1,
-			'visualeditor-enable' => 1,
 			'visualeditor-tabs' => 'multi-tab',
 		],
 	],


### PR DESCRIPTION
Done because this is set in MWS through `$wmgVisualEditorEnableDefault`.