### PR TITLE
Fix translate right declaration

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -2154,7 +2154,7 @@ $wgManageWikiExtensions = [
 					],
 					'user' => [
 						'permissions' => [
-							'translate-review',
+							'translate-messagereview',
 						],
 					],
 				],


### PR DESCRIPTION
 translate-review right does not exist in the Translate extension. I believe that was meant to say translate-messagereview which does exist