### PR TITLE
Migrate PageImages to ManageWikiExtensions

### DIFF
--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -877,7 +877,6 @@ if ( $wmgUsePortableInfobox ) {
 if ( $wmgUsePopups ) {
 	wfLoadExtensions( [
 		'TextExtracts',
-		'PageImages',
 		'Popups',
 	] );
 	

--- a/LocalExtensions.php
+++ b/LocalExtensions.php
@@ -834,6 +834,10 @@ if ( $wmgUsePageForms ) {
 	wfLoadExtension( 'PageForms' );
 }
 
+if ( $wmgUsePageImages ) {
+	wfLoadExtension( 'PageImages' );
+}
+
 if ( $wmgUsePageNotice ) {
 	wfLoadExtension( 'PageNotice' );
 }

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1183,6 +1183,9 @@ $wi->config->settings = [
 	'wmgUsePageForms' => [
 		'default' => false,
 	],
+	'wmgUsePageImages' => [
+		'default' => false,
+	],
 	'wmgUsePageNotice' => [
 		'default' => false,
 	],

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1571,7 +1571,11 @@ $wgManageWikiExtensions = [
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Popups',
 			'var' => 'wmgUsePopups',
 			'conflicts' => false,
-			'requires' => [],
+			'requires' => [
+				'extensions' => [
+					'pageimages',
+				],
+			],
 		],
 		'pollny' => [
 			'name' => 'PollNY',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1571,11 +1571,7 @@ $wgManageWikiExtensions = [
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Popups',
 			'var' => 'wmgUsePopups',
 			'conflicts' => false,
-			'requires' => [
-				'extensions' => [
-					'pageimages',
-				],
-			],
+			'requires' => [],
 		],
 		'pollny' => [
 			'name' => 'PollNY',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1492,6 +1492,13 @@ $wgManageWikiExtensions = [
 				],
 			],
 		],
+		'pageimages' => [
+			'name' => 'Page Images',
+			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:PageImages',
+			'var' => 'wmgUsePageImages',
+			'conflicts' => false,
+			'requires' => [],
+		],
 		'pagenotice' => [
 			'name' => 'Page Notice',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:PageNotice',
@@ -1564,7 +1571,10 @@ $wgManageWikiExtensions = [
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Popups',
 			'var' => 'wmgUsePopups',
 			'conflicts' => false,
-			'requires' => [],
+			'requires' => [
+				'extensions' => [
+					'pageimages',
+				],
 		],
 		'pollny' => [
 			'name' => 'PollNY',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1575,6 +1575,7 @@ $wgManageWikiExtensions = [
 				'extensions' => [
 					'pageimages',
 				],
+			],
 		],
 		'pollny' => [
 			'name' => 'PollNY',


### PR DESCRIPTION
Done because it has other uses besides just the popups extension, such as external api's that use it, like Discord Wiki-Bot. (https://phabricator.miraheze.org/T6480)