### PR TITLE
add $wgDefaultMobileSkin to ManageWikiSettings (T6488)

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2640,8 +2640,8 @@ $wi->config->settings = [
 	'wgMFAutodetectMobileView' => [
 		'default' => false,
 	],
-	'wgMFDefaultSkinClass' => [
-		'default' => 'SkinMinerva',
+	'wgDefaultMobileSkin' => [
+		'default' => 'minerva',
 	],
 	'wgMobileUrlTemplate' => [
 		'default' => '',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1929,7 +1929,17 @@ $wgManageWikiSettings = [
 		'options' => [],
 		'overridedefault' => 'vector',
 		'section' => 'styling',
-		'help' => 'This change the visual interface to the selected skin for all users, however it can be changed through user\'s preferences, unless the skin is added to <code>$wgSkipSkins</code> in the Preferences tab.',
+		'help' => 'Changes the visual interface to the selected skin for all users, however it can be changed through user\'s preferences, unless the skin is added to <code>$wgSkipSkins</code> in the Preferences tab.',
+	],
+	'wgDefaultMobileSkin' => [
+		'name' => 'Default Mobile Skin',
+		'from' => 'mobilefrontend',
+		'restricted' => false,
+		'type' => 'skin',
+		'options' => [],
+		'overridedefault' => 'minerva',
+		'section' => 'styling',
+		'help' => 'Changes the default mobile skin to be used by the Mobile Frontend extension. Some skins may not be compatable.',
 	],
 	'wgLogo' => [
 		'name' => 'Logo',


### PR DESCRIPTION
Seems since MediaWiki 1.35 that `$wgMFDefaultSkinClass` was renamed to `$wgDefaultMobileSkin`

https://github.com/wikimedia/mediawiki-extensions-MobileFrontend/blob/1421405c1fe4f3dbafe0cd18f43aa9054b974c4e/extension.json#L937