### PR TITLE
Fix typo for Extension:UrlGetParameters in ManageWiki/extensions link

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -2287,7 +2287,7 @@ $wgManageWikiExtensions = [
 			'requires' => [],
 		],
 		'urlgetparameters' => [
-			'name' => 'UrlGetParamters',
+			'name' => 'UrlGetParameters',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:UrlGetParameters',
 			'var' => 'wmgUseUrlGetParameters',
 			'conflicts' => false,


### PR DESCRIPTION
No change to name in database table, so no DB update should be needed. Thanks