### PR TITLE
Add c1 to wgCreateWikiDatabaseClustersInactive

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -503,7 +503,9 @@ $wi->config->settings += [
 	],
 	// Use if you want to stop wikis being created on this cluster
 	'wgCreateWikiDatabaseClustersInactive' => [
-		'default' => []
+		'default' => [
+			'c1',
+		]
 	],
 	'wgCreateWikiGlobalWiki' => [
 		'default' => 'metawiki',


### PR DESCRIPTION
c1 is the same as c2. But lets add c1 to wgCreateWikiDatabaseClustersInactive to prevent wikis changing db clusters.