### PR TITLE
Fix setting overrides for wgDefaultUserOptions

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2991,7 +2991,7 @@ $wi->config->settings += [
 	],
 
 	// Preferences
- 	'+wgDefaultUserOptions' => [
+ 	'wmgDefaultUserOptions' => [
  		'default' => [
  			'enotifwatchlistpages' => 0,
  			'math' => 'mathml',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3828,6 +3828,8 @@ if ( !file_exists( '/srv/mediawiki/w/cache/l10n/l10n_cache-en.cdb' ) ) {
 	$wi->config->settings['wgLocalisationCacheConf']['default']['manualRecache'] = false;
 }
 
+wgDefaultUserOptions
+
 // DumpDump rights
 $wgAvailableRights[] = 'view-dump';
 $wgAvailableRights[] = 'generate-dump';
@@ -3842,6 +3844,10 @@ $wi->config->extractAllGlobals( $wi->dbname );
 require_once __DIR__ . "/ManageWikiExtensions.php";
 require_once __DIR__ . "/ManageWikiNamespaces.php";
 require_once __DIR__ . "/ManageWikiSettings.php";
+
+// Due to an issue with +wgDefaultUserOptions not allowing wiki overrides,
+//we have to work around this by creating a local config and merging.
+$wgDefaultUserOptions = array_merge( $wgDefaultUserOptions, $wmgDefaultUserOptions );
 
 $wgUploadPath = "https://static.miraheze.org/$wgDBname";
 $wgUploadDirectory = "/mnt/mediawiki-static/$wgDBname";

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3828,8 +3828,6 @@ if ( !file_exists( '/srv/mediawiki/w/cache/l10n/l10n_cache-en.cdb' ) ) {
 	$wi->config->settings['wgLocalisationCacheConf']['default']['manualRecache'] = false;
 }
 
-wgDefaultUserOptions
-
 // DumpDump rights
 $wgAvailableRights[] = 'view-dump';
 $wgAvailableRights[] = 'generate-dump';


### PR DESCRIPTION
We create a new wmgDefaultUserOptions config which is local and then we add wmgDefaultUserOptions onto wgDefaultUserOptions by doing:

wgDefaultUserOptions = array_merge( $wgDefaultUserOptions, $wmgDefaultUserOptions );

Using + with wgDefaultUserOptions didn't appear to apply the overrides we had set in wgConf thus this change is necessary for this to work again.