### PR TITLE
Trying to make restriction levels ordered better

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3096,6 +3096,10 @@ $wi->config->settings += [
 			'member',
 		],
 		'+hypopediawiki' => [
+			'',
+			'user',
+			'autoconfirmed',
+			'sysop',
 			'bureaucrat',
 		],
 		'igrovyesistemywiki' => [


### PR DESCRIPTION
I am attempting to see if this would make the protection levels ordered more in a way that doesn't trigger my OCD in hypopediawiki (Yes, I am a bureaucrat and administrator there.) If anyone has a better way to approach this please suggest them to me. Thank you.