### PR TITLE
Redis: Remove persistent

### DIFF
--- a/Redis.php
+++ b/Redis.php
@@ -5,7 +5,6 @@ $wgObjectCaches['redis-central'] = [
 	'class' => 'RedisBagOStuff',
 	'servers' => [ $wmgRedisSettings['cache']['server'] ],
 	'password' => $wmgRedisSettings['cache']['password'],
-	'persistent' => true,
 	'loggroup' => 'redis',
 	'reportDupes' => false,
 ];


### PR DESCRIPTION
Not really needed as we use nutcracker thus doesn't make a connection to redis on each request.