### PR TITLE
Change HTML Meta and Title and SnapProjectEmbed's display name

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -33,7 +33,7 @@ $wgManageWikiExtensions = [
 			'requires' => [],
 		],
 		'htmlmetaadntitle' => [
-			'name' => 'HTML Meta and Title',
+			'name' => 'Add HTML Meta and Title',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Add_HTML_Meta_and_Title',
 			'var' => 'wmgUseAddHTMLMetaAndTitle',
 			'conflicts' => false,
@@ -1945,7 +1945,7 @@ $wgManageWikiExtensions = [
 			],
 		],
 		'snapprojectembed' => [
-			'name' => 'SnapProjectEmbed',
+			'name' => 'Snap! Project Embed',
 			'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:SnapProjectEmbed',
 			'var' => 'wmgUseSnapProjectEmbed',
 			'conflicts' => false,


### PR DESCRIPTION
Both of their names got changed and it is probably a good idea to update them in ManageWiki, too.