### PR TITLE
Add `loginwiki` & migrate `wikipedia` to default import source

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2001,7 +2001,9 @@ $wi->config->settings += [
 	'wgImportSources' => [
 		'default' => [
 			'meta',
+			'loginwiki',
 			'templatewiki',
+			'wikipedia',
 		],
 		'+batfamilywiki' => [
 			'batmanwiki',
@@ -2014,9 +2016,6 @@ $wi->config->settings += [
 		'+incubatorwiki' => [
 			'wmincubator',
 			'wikiaincubatorplus',
-		],
-		'+metawiki' => [
-			'wikipedia',
 		],
 		'+mrjaroslavikwiki' => [
 		        'wikipedia' => [
@@ -2037,9 +2036,6 @@ $wi->config->settings += [
 		'+sesupportwiki' => [
 			'mrjaroslavikwiki',
 		],
-		'+simcitywiki' => [
-			'wikipedia',
-		],
 		'+snapwikiwiki' => [
 			'scratchwiki',
 		],
@@ -2049,7 +2045,6 @@ $wi->config->settings += [
 			],
 		],
 		'+zhdelwiki' => [
-			'wikipedia',
 			'zhwikipedia',
 		],
 	],


### PR DESCRIPTION
This PR does a couple things. Firstly, it adds `loginwiki` to the `default` import sources, essential for transwiki importation from Loginwiki. Contemplated adding only to Meta Wiki's import sources, but given the global nature of Loginwiki and the high likelihood imports will want to be done across multiple wikis, it makes sense to add it globally. Secondly, this PR also migrates `wikipedia` from local sources to `default` given nearly every wiki commonly imports pages and templates from Wikipedia.