### PR TITLE
Add Science category to CreateWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -566,6 +566,7 @@ $wi->config->settings += [
 			'Politics' => 'politics',
 			'Private' => 'private',
 			'Religion' => 'religion',
+			'Science' => 'science',
 			'Software/Computing' => 'software',
 			'Sports' => 'sport',
 			'Uncategorised' => 'uncategorised',


### PR DESCRIPTION
We have a quite a number of wikis related to science-related topics, including astronomy, physics, physical and environmental sciences. We have _Education_, yes, but we also have _Medical/Medicine_, which describes topically the wiki. Education tells only _who_ uses it, not what the wiki is about.