### PR TITLE
Remove short term sitenotice that uploading is available

### DIFF
--- a/Sitenotice.php
+++ b/Sitenotice.php
@@ -1,6 +1,6 @@
 <?php
 
-/* if ( $wmgSiteNoticeOptOut ) {
+if ( $wmgSiteNoticeOptOut ) {
 	// only show important notices when optout
 	$wi->config->settings['wgNoticeProject']['default'] = 'optout';
 }
@@ -10,7 +10,7 @@
 // and don't comment it out
 $wgMajorSiteNoticeID = 56;
 
-if ( !$wmgSiteNoticeOptOut ) {
+/* if ( !$wmgSiteNoticeOptOut ) {
 	$wgHooks['SiteNoticeAfter'][] = 'onSiteNoticeAfter'; // show to all users
 	function onSiteNoticeAfter( &$siteNotice, $skin ) {
 		global $wmgSiteNoticeOptOut, $snImportant;

--- a/Sitenotice.php
+++ b/Sitenotice.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( $wmgSiteNoticeOptOut ) {
+/* if ( $wmgSiteNoticeOptOut ) {
 	// only show important notices when optout
 	$wi->config->settings['wgNoticeProject']['default'] = 'optout';
 }
@@ -21,4 +21,4 @@ if ( !$wmgSiteNoticeOptOut ) {
 			</tr></tbody></table>
 		EOF;
 	}
-}
+} */


### PR DESCRIPTION
Several announcements on Discord together with this short sitenotice and the fact that actually uploading files will make it clear that uploads are again available. No need for more than a few hour sitenotice.