### PR TITLE
Add wgWatchlistExpiry to ManageWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -822,6 +822,9 @@ $wi->config->settings += [
 	'wmgShowPopupsByDefault' => [
 		'default' => false,
 	],
+	'wgWatchlistExpiry' => [
+		'default' => false,
+	],
 
 	// Extensions and Skins
 	'wmgUse3D' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -578,6 +578,15 @@ $wgManageWikiSettings = [
 		'help' => 'Default Page Previews visibility. Has to be a string as a compatibility with beta feature settings.',
 		'requires' => [],
 	],
+	'wgWatchlistExpiry' => [
+		'name' => 'Watchlist Expiry',
+		'from' => 'mediawiki',
+		'type' => 'check',
+		'overridedefault' => true,
+		'section' => 'edit',
+		'help' => 'Whether to allow users to select a expiry time when adding an item to their watchlist',
+		'requires' => [],
+	],
 
 	// Links
 	'wgArticleCountMethod' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -579,10 +579,10 @@ $wgManageWikiSettings = [
 		'requires' => [],
 	],
 	'wgWatchlistExpiry' => [
-		'name' => 'Watchlist Expiry',
+		'name' => 'Allow Watchlist Expiry Time',
 		'from' => 'mediawiki',
 		'type' => 'check',
-		'overridedefault' => true,
+		'overridedefault' => false,
 		'section' => 'edit',
 		'help' => 'Whether to allow users to select a expiry time when adding an item to their watchlist',
 		'requires' => [],


### PR DESCRIPTION
Adds ``wgWatchlistExpiry`` to ManageWiki which is no longer marked as experimental since 1.35.1.