### PR TITLE
Change default matomo id

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2660,8 +2660,11 @@ $wi->config->settings += [
 	'wgMatomoAnalyticsUseDB' => [
 		'default' => true,
 	],
+	'wgMatomoAnalyticsSiteID' => [
+		'default' => 8590,
+	],
 	'wgMatomoAnalyticsGlobalID' => [
-		'default' => 1,
+		'default' => 8590,
 	],
 	'wgMatomoAnalyticsDisableCookie' => [
 		'default' => true,


### PR DESCRIPTION
Due to a bug in the Matomo extension, we've accidentally deleted the default id.

So we change it to the new one so we have a centralised analytics.