### PR TITLE
Add Art & Architecture category to CreateWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -701,6 +701,7 @@ $wi->config->settings += [
 	],
 	'wgCreateWikiCategories' => [
 		'default' => [
+			'Art & Arcitecture' -> 'artarc',
 			'Automotive' => 'automotive',
 			'Community' => 'community',
 			'Education' => 'education',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -701,7 +701,7 @@ $wi->config->settings += [
 	],
 	'wgCreateWikiCategories' => [
 		'default' => [
-			'Art & Arcitecture' => 'artarc',
+			'Art & Architecture' => 'artarc',
 			'Automotive' => 'automotive',
 			'Community' => 'community',
 			'Education' => 'education',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -701,7 +701,7 @@ $wi->config->settings += [
 	],
 	'wgCreateWikiCategories' => [
 		'default' => [
-			'Art & Arcitecture' -> 'artarc',
+			'Art & Arcitecture' => 'artarc',
 			'Automotive' => 'automotive',
 			'Community' => 'community',
 			'Education' => 'education',


### PR DESCRIPTION
We do get quite a few wikis that propose to create either a wiki about buildings and other real world infrastructure. Combining with "Art", as is common, also means this could potentially be used for the many artist repository wikis or even fan-made original character repositories/catalogues, too. It's also a common categorization