### PR TITLE
Add "None of the above" to CreateWiki Purposes

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -666,6 +666,7 @@ $wi->config->settings += [
 			'Roleplaying game wiki' => 'Roleplaying game wiki',
 			'Video game (specified video game) information wiki' => 'Video game (specified video game) information wiki',
 			'Video game (broad genre or video game series) information wiki' => 'Video game (broad genre or video game series) information wiki',
+			'None of the above' => 'None of the above',
 		],
 	],
 	'wgCreateWikiShowBiographicalOption' => [


### PR DESCRIPTION
It is a very bad idea to assume we have all possible purposes for wikis.