### PR TITLE
Change wgExtraLanguageNames for isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2210,9 +2210,7 @@ $wi->config->settings += [
 	'wgExtraLanguageNames' => [
 		'default' => [],
 		'isvwiki' => [
-			'isv' => [
-				'Medžuslovjansky',
-			],
+			'isv' => 'Medžuslovjansky / Меджусловјанскы',
 		],
 	],
 


### PR DESCRIPTION
The current configuration introduced in https://github.com/miraheze/mw-config/commit/1a899d9d5ee879b06cf8d622b3fa4dcf9fc6754c makes the language display as `isv - Array` or `isv - isv`. [mediawiki.org says](https://www.mediawiki.org/wiki/Manual:$wgExtraLanguageNames) that a string is needed.