### PR TITLE
Configure LinkTitles for simulatorwiki per T7094

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2463,6 +2463,10 @@ $wi->config->settings += [
 	],
 	
 	// LinkTitles
+	'wgLinkTitlesFirstOnly' => [
+		'default' => true,
+		'simulatorwiki' => false,
+	],
 	'wgLinkTitlesParseOnEdit' => [
 		'default' => true,
 		'simulatorwiki' => false,


### PR DESCRIPTION
Missed a variable in #3814, oops (per [T7094](https://phabricator.miraheze.org/T7094))