### PR TITLE
Add MediaWiki as transwiki import source to memeswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2186,6 +2186,9 @@ $wi->config->settings += [
 			'wmincubator',
 			'wikiaincubatorplus',
 		],
+		'+memeswiki' => [
+			'mw',
+		],
 		'+mrjaroslavikwiki' => [
 			'wikipedia' => [
 				'cs',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2168,6 +2168,7 @@ $wi->config->settings += [
 		'default' => [
 			'meta',
 			'loginwiki',
+			'mw',
 			'templatewiki',
 			'wikipedia',
 		],
@@ -2185,9 +2186,6 @@ $wi->config->settings += [
 		'+incubatorwiki' => [
 			'wmincubator',
 			'wikiaincubatorplus',
-		],
-		'+memeswiki' => [
-			'mw',
 		],
 		'+mrjaroslavikwiki' => [
 			'wikipedia' => [


### PR DESCRIPTION
Requested by WikiJS (Justin) on IRC, #miraheze channel

I can actually see this added as a `default` source, but for now, will add it here. Let me know if you'd prefer I change it to `default`.