### PR TITLE
Disable wgCosmosEnabledRailModules['recentchanges'] on some wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -583,6 +583,27 @@ $wi->config->settings += [
 				'cosmos-custom-sticky-rail-module' => 'sticky',
 			],
 		],
+		'batfamilywiki' => [
+			'recentchanges' => false,
+			'interface' => [
+				'cosmos-custom-rail-module' => 'normal',
+				'cosmos-custom-sticky-rail-module' => 'sticky',
+			],
+		],
+		'batmanwiki' => [
+			'recentchanges' => false,
+			'interface' => [
+				'cosmos-custom-rail-module' => 'normal',
+				'cosmos-custom-sticky-rail-module' => 'sticky',
+			],
+		],
+		'snapwikiwiki' => [
+			'recentchanges' => false,
+			'interface' => [
+				'cosmos-custom-rail-module' => 'normal',
+				'cosmos-custom-sticky-rail-module' => 'sticky',
+			],
+		],
 		'thewhiteroomwiki' => [
 			'recentchanges' => false,
 			'interface' => [


### PR DESCRIPTION
Requested by R4356th on the Cosmos Discord server.