### PR TITLE
Configure permissions for DataTransfer (T7149)

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1205,6 +1205,15 @@ $wgManageWikiExtensions = [
 			'conflicts' => false,
 			'requires' => [],
 			'section' => 'specialpages',
+			'install' => [
+				'permissions' => [
+					'sysop' => [
+						'permissions' => [
+							'datatransferimport',
+						]
+					]
+				],
+			],
 		],
 		'editcount' => [
 			'name' => 'EditCount',


### PR DESCRIPTION
The permissions were never configured for the DataTransfer extension which caused the issue mentioned in T7149.