### PR TITLE
Change html attributes to prevent Google crawling sitenotice

### DIFF
--- a/Sitenotice.php
+++ b/Sitenotice.php
@@ -24,7 +24,8 @@ $wgMajorSiteNoticeID = 56;
 	}
 } */
 
-
+// Wrap your sitenotice with <div data-nosnippet>(sitenotice)</div>
+// or Google will use the sitenotice for their search result snippet.
 // Specific wiki sitenotice
 if ( $wgDiscordIncomingWebhookUrl || $wgSlackIncomingWebhookUrl ) {
 $wgHooks['SiteNoticeAfter'][] = 'onSiteNoticeAfter';
@@ -32,9 +33,9 @@ function onSiteNoticeAfter( &$siteNotice, $skin ) {
 	global $wmgSiteNoticeOptOut, $snImportant;
 
 	$siteNotice .= <<<EOF
-			<table class="wikitable" style="text-align:center;"><tbody><tr>
+			<div data-nosnippet><table class="wikitable" style="text-align:center;"><tbody><tr>
 			<td>Unfortunately, Between 3 January 2021 and 28 April 2021, Discord & Slack Webhook URLs were available via the MediaWiki API due to <a href="https://github.com/miraheze/ManageWiki/security/advisories/GHSA-jmc9-rv2f-g8vv">GHSA-jmc9-rv2f-g8vv</a>. We advise you to consider resetting and replacing your Discord or Slack webhook via Special:ManageWiki/settings.</td>
-			</tr></tbody></table>
+			</tr></tbody></table></div>
 EOF;
 		return true;
 	}


### PR DESCRIPTION
This ensures Google does not use the sitenotice as a snippet for their search result for Miraheze wikis who has not set one via extensions like WikiSEO. [Plaintexts here will be impacted](https://phabricator.miraheze.org/F1430638). Please ensure all future sitenotices and centralnotices has this value.


Cf. https://revi.kr/6bFF ( https://developers.google.com/search/docs/advanced/robots/robots_meta_tag?hl=en#data-nosnippet-attr )