### PR TITLE
Fix case

### DIFF
--- a/Sitenotice.php
+++ b/Sitenotice.php
@@ -34,7 +34,7 @@ function onSiteNoticeAfter( &$siteNotice, $skin ) {
 
 	$siteNotice .= <<<EOF
 			<div data-nosnippet><table class="wikitable" style="text-align:center;"><tbody><tr>
-			<td>Unfortunately, Between 3 January 2021 and 28 April 2021, Discord & Slack Webhook URLs were available via the MediaWiki API due to <a href="https://github.com/miraheze/ManageWiki/security/advisories/GHSA-jmc9-rv2f-g8vv">GHSA-jmc9-rv2f-g8vv</a>. We advise you to consider resetting and replacing your Discord or Slack webhook via Special:ManageWiki/settings.</td>
+			<td>Unfortunately, between 3 January 2021 and 28 April 2021, Discord & Slack Webhook URLs were available via the MediaWiki API due to <a href="https://github.com/miraheze/ManageWiki/security/advisories/GHSA-jmc9-rv2f-g8vv">GHSA-jmc9-rv2f-g8vv</a>. We advise you to consider resetting and replacing your Discord or Slack webhook via Special:ManageWiki/settings.</td>
 			</tr></tbody></table></div>
 EOF;
 		return true;


### PR DESCRIPTION
One more fix to this sitenotice. The other thing I was wondering if for `Special:ManageWiki/settings`, I'm wondering if we could make that into a link with `<a href="https:" + $wgServer + "/wiki/Special:ManageWiki/settings">Special:ManageWiki/settings</a>`? I just never know if we need a `+` before and/or after the `$wgServer` variable?