### PR TITLE
Test change in FlaggedRevs config for isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1794,8 +1794,8 @@ $wi->config->settings += [
 		],
 		'isvwiki' => [
 			'status' => [
+				'quality' => 1,
 				'levels' => 1,
-				'quality' => 2,
 				'pristine' => 4,
 			],
 		],


### PR DESCRIPTION
As I've reported earlier, [FlaggedRevs autoreview does not work on isvwiki](https://phabricator.miraheze.org/T7032) despite all the necessary user rights and ManageWiki settings set. Other wikis have no problem with it, however:
1. https://nomenber.miraheze.org/wiki/Special:Log?type=review&user=&page=&wpdate=&tagfilter=&subtype=autoaccept
2. https://excelletdiscordservers.miraheze.org/wiki/Special:Log?type=review&user=&page=&wpdate=&tagfilter=&subtype=autoaccept

(Thanks to Reception123 for compiling the list for me.)

As I don't know the cause for this, I've decided to test this change that makes it as close to default as possible (other than changing the default level). If there are better ways to write this, feel free to change it.

If this does not work, I'll just stop using the extension.