### PR TITLE
#T7283 - add protection level to allpediawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2655,6 +2655,11 @@ $wi->config->settings += [
 				'userrights' => true,
 			],
 		],
+    		'+allpediawiki' => [
+			'extendedconfirmed' => [
+				'editextendedconfirmedprotected' => true,
+			],
+		],
 		'+autocountwiki' => [
 			'authors' => [
 				'torunblocked' => true,
@@ -3657,6 +3662,11 @@ $wi->config->settings += [
 			'autoconfirmed',
 			'sysop'
 		],
+    		'+allpediawiki' => [
+			'extendedconfirmed' => [
+				'editextendedconfirmedprotected' => true,
+			],
+		],
 		'+ahinfoboxeswiki' => [
 			'editrollbackprotected',
 			'edittemplateprotected',
@@ -3741,6 +3751,11 @@ $wi->config->settings += [
 	// Rights
 	'+wgAvailableRights' => [
 		'default' => [],
+    		'+allpediawiki' => [
+			'extendedconfirmed' => [
+				'editextendedconfirmedprotected' => true,
+			],
+		],
 		'ahinfoboxeswiki' => [
 			'editrollbackprotected',
 			'edittemplateprotected',


### PR DESCRIPTION
Add `extendedconfirmed` protection level to `allpediawiki` per [T7283](https://phabricator.miraheze.org/T7283)