### PR TITLE
Add protection/restriction level to hypopediawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2710,6 +2710,9 @@ $wi->config->settings += [
 			'bureaucrat' => [
 				'bureaucrat' => true,
 			],
+			'extendedconfirmed' => [
+				'editextendedconfirmedprotected' => true,
+			],
 		],
 		'+igrovyesistemywiki' => [
 			'autopatrolled' => [
@@ -3716,6 +3719,7 @@ $wi->config->settings += [
 		],
 		'+hypopediawiki' => [
 			'bureaucrat',
+			'editextendedconfirmedprotected',
 		],
 		'+igrovyesistemywiki' => [
 			'trusted',
@@ -3791,6 +3795,9 @@ $wi->config->settings += [
 		'famepediawiki' => [
 			'editextendedconfirmedprotected',
 			'edittemplateprotected',
+		],
+		'hypopediawiki' => [
+			'editextendedconfirmedprotected',
 		],
 		'lhmnwiki' => [
 			'editextendedconfirmedprotected',


### PR DESCRIPTION
Per [#T7368](https://phabricator.miraheze.org/T7368), adding `editextendedconfirmedprotected` restriction/protection level to `extendedconfirmed` user group on `hypopediawiki`