### PR TITLE
Add ``snapwikiwiki`` as an Import Source For ``snapdatawiki``

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2263,6 +2263,7 @@ $wi->config->settings += [
 		],
 		'+snapdatawiki' => [
 			'd',
+			'snapwiki',
 		],
 		'+snapwikiwiki' => [
 			'scratchwiki',


### PR DESCRIPTION
I am a bureaucrat on that wiki and can confirm that we want to import pages from ``snapwikiwiki`` there.