### PR TITLE
Configure wgRottenLinksExcludeWebsites for snapwikiwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3830,6 +3830,7 @@ $wi->config->settings += [
 		'snapwikiwiki' => [
 			'smerge.imp.fu-berlin.de',
 			'www.hinkler.com.au',
+		],
 	],
 
 	// Robot policy

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3827,6 +3827,9 @@ $wi->config->settings += [
 			'localhost',
 			'127.0.0.1',
 		],
+		'snapwikiwiki' => [
+			'smerge.imp.fu-berlin.de',
+			'www.hinkler.com.au',
 	],
 
 	// Robot policy

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3827,7 +3827,7 @@ $wi->config->settings += [
 			'localhost',
 			'127.0.0.1',
 		],
-		'snapwikiwiki' => [
+		'+snapwikiwiki' => [
 			'smerge.imp.fu-berlin.de',
 			'www.hinkler.com.au',
 		],


### PR DESCRIPTION
`smerge.imp.fu-berlin.de` and `www.hinkler.com.au` are way too slow in responding to requests.