### PR TITLE
Add reception wiki as Wiki Purpose

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -748,6 +748,7 @@ $wi->config->settings += [
 			'Organization (coordination) wiki' => 'Organization (coordination) wiki',
 			'Political simulation wiki' => 'Political simulation wiki',
 			'Roleplaying game wiki' => 'Roleplaying game wiki',
+			'Reception wiki' => 'Reception wiki',
 			'Video game (specified video game) information wiki' => 'Video game (specified video game) information wiki',
 			'Video game (broad genre or video game series) information wiki' => 'Video game (broad genre or video game series) information wiki',
 			'None of the above' => 'None of the above',


### PR DESCRIPTION
A large portion of Miraheze wikis is Reception wikis, so I think it would be appropriate to add this as a wiki purpose in CW.