### PR TITLE
silence mediawiki deprecation warnings post 1.35

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4729,7 +4729,7 @@ $wi->config->settings += [
 			'XMP' => false,
 		],
 	],
-	// Contro MediaWiki Deprecation Warnings
+	// Control MediaWiki Deprecation Warnings
 	'wgDeprecationReleaseLimit' => [
 		'default' => '1.35',
 		'test3wiki' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4730,7 +4730,7 @@ $wi->config->settings += [
 		],
 	],
 	// Contro MediaWiki Deprecation Warnings
-	'wgDeprecationReleaseLimit' = [
+	'wgDeprecationReleaseLimit' => [
 		'default' => '1.35',
 		'test3wiki' => false,
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4729,6 +4729,11 @@ $wi->config->settings += [
 			'XMP' => false,
 		],
 	],
+	// Contro MediaWiki Deprecation Warnings
+	'wgDeprecationReleaseLimit' = [
+		'default' => '1.35',
+		'test3wiki' => false,
+	],
 
 	// Email notifications on privileged actions configuration
 	'wgMirahezeMagicLogEmailConditions' => [


### PR DESCRIPTION
Deprecation warnings are sent to the mediawiki error channel in logging, and given the prevalence of some extensions using deprecated hooks (HideSection, Variables, DiscordNotifications), these warnings flood our logging infrastructure beyond what is reasonable.