### PR TITLE
test3: test a theory

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -206,7 +206,7 @@ $wi->config->settings += [
 
 	// Cache
 	'wgCacheDirectory' => [
-		'default' => '/srv/mediawiki/cache',
+		'default' => '/srv/mediawiki-staging/l10ncache',
 	],
 	'wgExtensionEntryPointListFiles' => [
 		'default' => [


### PR DESCRIPTION
to see if we can deploy mediawiki patches locally for sec issues and potentially save time on git clones, try put stuff in mediawiki-staging.

If I can figure a process, we might need to pick one of the mw* and then start with the new sync system.

Most of it could naturally run by a post-deploy bash file.