### PR TITLE
Remove ENV for GDFONTPATH

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4828,9 +4828,6 @@ if ( extension_loaded( 'wikidiff2' ) ) {
 	$wgDiff = false;
 }
 
-// Fonts
-putenv( "GDFONTPATH=/usr/share/fonts/truetype/freefont" );
-
 // Varnish
 
 // We set wgInternalServer to wgServer as we need this to get purging working (we convert wgServer from https:// to http://).


### PR DESCRIPTION
Since 1.36, this no longer works, extension previously using this, like Timeline now have to specify the path within the extension themselves in order to access this. This is due to changes with shell restrictions in 1.36.