### PR TITLE
Make AMC mode default for registered users on isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3688,6 +3688,7 @@ $wi->config->settings += [
 		],
 		'+isvwiki' => [
 			'flow-topiclist-sortby' => 'newest',
+			'mf_amc_optin' => '1',
 		],
 		'+reviwikiwiki' => [
 			'rcenhancedfilters-disable' => 1,


### PR DESCRIPTION
This pull request should enable Advanced Mobile Contributions by default for registered users in isvwiki. It would not affect anonymous users since they cannot use.

Code link:
https://github.com/wikimedia/mediawiki-extensions-MobileFrontend/blob/master/includes/Amc/UserMode.php

I also wonder whether it is possible to set `wgMinervaTalkAtTop` in isvwiki for mobile readers here, but since that variable it does not exist in the file at the moment, I did not do it in this request. Link for this (look for wgMinervaTalkAtTop, like in svwiki): https://noc.wikimedia.org/conf/InitialiseSettings.php.txt.