### PR TITLE
[REVERT: EMERGENCY] remove emergency measure

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -96,12 +96,12 @@ $wi->config->settings += [
 	],
 	'wgAbuseFilterEmergencyDisableThreshold' => [
 		'default' => [
-			'default' => 0.60,
+			'default' => 0.05,
 		],
 	],
 	'wgAbuseFilterEmergencyDisableCount' => [
 		'default' => [
-			'default' => 40,
+			'default' => 2,
 		],
 	],
 


### PR DESCRIPTION
Filters are still way above so let's hope no one edits them. Warnings have been given.

https://meta.miraheze.org/wiki/Spam_blacklist exists for a reason as a replacement for most of 18 but is rarely edited anyway and 19 doesn't need editing outside of a mediawiki upgrade so shouldn't be an issue.