### PR TITLE
Setting image repository for polandballwikisongcontestwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -321,7 +321,7 @@ if ( $wgDBname === 'polandballwikisongcontestwiki' ) {
 		'descriptionCacheExpiry' => 86400 * 7,
 		'thumbScriptUrl' => false,
 		'transformVia404' => !$wgGenerateThumbnailOnParse,
-		'hasSharedCache' => 'polcomwiki',
+		'hasSharedCache' => false,
 		'wiki' => 'polcomwiki',
 		'descBaseUrl' => 'https://commons.polandballwiki.com/wiki/File:',
 	];

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -309,7 +309,23 @@ if ( $wgDBname === 'commonswiki' ) {
 		'url' => 'https://commons.miraheze.org/w/api.php'
 	];
 }
-
+// Image repository for polandballwikisongcontestwiki
+if ( $wgDBname === 'polandballwikisongcontestwiki' ) {
+	$wgForeignFileRepos[] = [
+		'class' => 'ForeignDBViaLBRepo',
+		'name' => 'shared-polcomwiki',
+		'directory' => '/mnt/mediawiki-static/polcomwiki',
+		'url' => 'https://static.miraheze.org/polcomwiki',
+		'hashLevels' => $wgHashedSharedUploadDirectory ? 2 : 0,
+		'fetchDescription' => true,
+		'descriptionCacheExpiry' => 86400 * 7,
+		'thumbScriptUrl' => false,
+		'transformVia404' => !$wgGenerateThumbnailOnParse,
+		'hasSharedCache' => 'polcomwiki',
+		'wiki' => 'polcomwiki',
+		'descBaseUrl' => 'https://commons.polandballwiki.com/wiki/File:',
+	];
+}
 // Licensing variables
 switch ( $wmgWikiLicense ) {
 	case 'arr':


### PR DESCRIPTION
I was unable to enable shared image repository via ManageWiki for `polandballwikisongcontestwiki` to use `polcomwiki` as an image repo as `$wmgSharedUploadClientDBname` was already filled on `polcomwiki` by another wiki thus making it impossible to allow multiple wikis to use a single shared repository. I am proposing this manual change to allow the wiki in question to use the `polcomwiki` as an image repository.