### PR TITLE
Adding Import Sources for wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2344,6 +2344,7 @@ $wi->config->settings += [
 			'polcomwiki',
 		],
 		'+polcomwiki' => [
+			'c',
 			'polandballwiki',
 			'polandballwikisongcontestwiki',
 		],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2338,6 +2338,15 @@ $wi->config->settings += [
 				'en',
 			],
 		],
+		'+polandballstaffwiki' => [
+			'polandballwiki',
+			'polandballwikisongcontestwiki',
+			'polcomwiki',
+		],
+		'+polcomwiki' => [
+			'polandballwiki',
+			'polandballwikisongcontestwiki',
+		],
 		'+redminwiki' => [
 			'scratchwiki',
 			'snapwiki',


### PR DESCRIPTION
I added some import sources (`$wgImportSources`) to `polcomwiki` and `polandballstaffwiki`, as requested by the admins of these wikis on Discord.