### PR TITLE
Set $wgParserCacheType to cache in the DB

### DIFF
--- a/GlobalCache.php
+++ b/GlobalCache.php
@@ -37,7 +37,7 @@ $wgSessionsInObjectCache = true;
 
 $wgMessageCacheType = 'memcached-mem-1';
 $wgUseLocalMessageCache = true;
-$wgParserCacheType = 'memcached-mem-1';
+$wgParserCacheType = CACHE_DB;
 $wgLanguageConverterCacheType = 'memcached-mem-1';
 
 $jobrunnerSettings = $wmgCacheSettings['jobrunner'];


### PR DESCRIPTION
We have limited amount of memory so lets use the db where we have more space to store the cache longer.