### PR TITLE
Set $wgScribuntoDefaultEngine to luasandbox

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5024,6 +5024,8 @@ if ( $wgRequestTimeLimit ) {
 	$wgHTTPMaxTimeout = $wgHTTPMaxConnectTimeout = $wgRequestTimeLimit;
 }
 
+$wgScribuntoDefaultEngine = 'luasandbox';
+
 // Include other configuration files
 require_once '/srv/mediawiki/config/Database.php';
 require_once '/srv/mediawiki/config/GlobalCache.php';


### PR DESCRIPTION
Prevent having to check the lua sandbox version on each page load for it to just set luasandbox anyways.