### PR TITLE
Stop setting apiThumbCacheExpiry for commons

### DIFF
--- a/Defines.php
+++ b/Defines.php
@@ -203,20 +203,6 @@ if ( $wgDBname !== 'commonswiki' && $wgMirahezeCommons ) {
 	];
 }
 
-if ( $wgUseInstantCommons ) {
-	$wgHooks['MediaWikiServices'][] = 'onMediaWikiServices';
-
-	function onMediaWikiServices() {
-		global $wgForeignFileRepos;
-
-		foreach ( $wgForeignFileRepos as $key => $value ) {
-			if ( isset( $value['name'] ) && $value['name'] === 'wikimediacommons' ) {
-				$wgForeignFileRepos[$key]['apiThumbCacheExpiry'] = 86400;
-			}
-		}
-	}
-}
-
 // $wgLogos
 $wgLogos = [
 	'1x' => $wgLogo,


### PR DESCRIPTION
For some reason it seems that it's faster without this.