### PR TITLE
Adding wgDiscordNotificationAfterImportPage to settings

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1440,7 +1440,7 @@ $wgManageWikiSettings = [
 		'requires' => [],
 	],
 	'wgDiscordNotificationAfterImportPage' => [
-		'name' => 'Discord Notification Import Article',
+		'name' => 'Discord Notification After Article Import',
 		'from' => 'mediawiki',
 		'type' => 'check',
 		'overridedefault' => true,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1439,6 +1439,15 @@ $wgManageWikiSettings = [
 		'help' => 'Notify when an article is protected?',
 		'requires' => [],
 	],
+	'wgDiscordNotificationAfterImportPage' => [
+		'name' => 'Discord Notification Import Article',
+		'form' => 'mediawiki',
+		'type' => 'check',
+		'overridedefault' => true,
+		'section' => 'notifications',
+		'help' => 'Notify when a page is imported?'
+		'requires' => [],
+	],
 	'wgSlackIncomingWebhookUrl' => [
 		'name' => 'Slack Incoming Webhook URL',
 		'from' => 'slacknotifications',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1441,7 +1441,7 @@ $wgManageWikiSettings = [
 	],
 	'wgDiscordNotificationAfterImportPage' => [
 		'name' => 'Discord Notification Import Article',
-		'form' => 'mediawiki',
+		'from' => 'mediawiki',
 		'type' => 'check',
 		'overridedefault' => true,
 		'section' => 'notifications',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1445,7 +1445,7 @@ $wgManageWikiSettings = [
 		'type' => 'check',
 		'overridedefault' => true,
 		'section' => 'notifications',
-		'help' => 'Notify when a page is imported?'
+		'help' => 'Notify when a page is imported?',
 		'requires' => [],
 	],
 	'wgSlackIncomingWebhookUrl' => [


### PR DESCRIPTION
Requested on Discord; adding $wgDiscordNotificationAfterImportPage to ManageWiki Settings which controls whether a notification is generated when a page is imported or not