### PR TITLE
Raise DPL requirement to 40,000 pages

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -374,7 +374,7 @@ $wgManageWikiExtensions = [
 		'var' => 'wmgUseDynamicPageList',
 		'conflicts' => 'dynamicpagelist3',
 		'requires' => [
-			'pages' => 30000,
+			'pages' => 40000,
 		],
 		'section' => 'parserhooks',
 	],
@@ -384,7 +384,7 @@ $wgManageWikiExtensions = [
 		'var' => 'wmgUseDynamicPageList3',
 		'conflicts' => 'dynamicpagelist',
 		'requires' => [
-			'pages' => 30000,
+			'pages' => 40000,
 		],
 		'install' => [
 			'mwscript' => [


### PR DESCRIPTION
DPL3 at least should not have as much performance issues anymore. This can probably be further increased later on, but 40,000 is enough for now to gradually increase and see if issues continue to happen.