### PR TITLE
Enable `slow-parsoid` logging

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4206,6 +4206,7 @@ $wi->config->settings += [
 			'session-ip' => 'info',
 			'SimpleAntiSpam' => false,
 			'slow-parse' => 'debug',
+			'slow-parsoid' => 'debug',
 			'SocialProfile' => false,
 			'SpamBlacklist' => false,
 			'SpamBlacklistHit' => false,


### PR DESCRIPTION
Added in MediaWiki 1.37.0.