### PR TITLE
LS: unset wgSharedDB on test3wiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -974,7 +974,7 @@ $wi->config->settings += [
 		'default' => false,
 	],
 	'wgSharedDB' => [
-		'default' => 'metawiki', // REMOVE? 
+		'default' => 'metawiki', // REMOVE?
 		'test3wiki' => null,
 	],
 	'wgSharedTables' => [


### PR DESCRIPTION
Doesn't look needed but I don't want to break something that has been there 6 years.

Was added in https://github.com/miraheze/mw-config/commit/a01c7af66f062ce28ce641cd289d57323a5aa038 and made useless in https://github.com/miraheze/mw-config/commit/d2ed3e3867dc8021e4228e9a2c763c5b63b4e930