### PR TITLE
LS: remove wgSharedDB

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -973,9 +973,6 @@ $wi->config->settings += [
 	'wgReadOnly' => [
 		'default' => false,
 	],
-	'wgSharedDB' => [
-		'default' => null,
-	],
 	'wgSharedTables' => [
 		'default' => [],
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -974,8 +974,7 @@ $wi->config->settings += [
 		'default' => false,
 	],
 	'wgSharedDB' => [
-		'default' => 'metawiki', // REMOVE?
-		'test3wiki' => null,
+		'default' => null,
 	],
 	'wgSharedTables' => [
 		'default' => [],


### PR DESCRIPTION
Doesn't seem needed, spotted while auditing config in prep for future projects.

Anyone know why not? It has no effect.

This follows up 920d4b31844416a872c605979fabc8a0cc5e0385 and effectively reverts a01c7af