### PR TITLE
Remove references to quircwiki and rf1botwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2080,11 +2080,6 @@ $wi->config->settings += [
 	],
 	'wgManageWikiPermissionsAdditionalAddGroups' => [
 		'default' => [],
-		'rf1botwiki' => [
-			'bureaucrat' => [
-				'Repo_Maintainer',
-			],
-		],
 		'sesupportwiki' => [
 			'sysop' => [
 				'editor',
@@ -2322,16 +2317,6 @@ $wi->config->settings += [
 				'edit-admin-pages' => true,
 			],
 		],
-		'+quircwiki' => [
-			'QuIRC_Staff' => [
-				'editstaffprotected' => true,
-			],
-		],
-		'+rf1botwiki' => [
-			'Repo_Maintainer' => [
-				'editrepos' => true,
-			],
-		],
 		'+sesupportwiki' => [
 			'editor' => [
 				'editor' => true,
@@ -2383,11 +2368,6 @@ $wi->config->settings += [
 	],
 	'wgManageWikiPermissionsAdditionalRemoveGroups' => [
 		'default' => [],
-		'rf1botwiki' => [
-			'bureaucrat' => [
-				'Repo_Maintainer',
-			],
-		],
 		'sesupportwiki' => [
 			'sysop' => [
 				'editor',
@@ -3357,12 +3337,6 @@ $wi->config->settings += [
 		'+naasgamelandwiki' => [
 			'editarchiveprotected',
 			'editofficialprotected',
-		],
-		'+quircwiki' => [
-			'editstaffprotected',
-		],
-		'+rf1botwiki' => [
-			'editrepos',
 		],
 		'+sesupportwiki' => [
 			'editor',


### PR DESCRIPTION
For the former, per the wiki's requested deletion (https://meta.miraheze.org/w/index.php?title=Stewards%27_noticeboard&oldid=210656#Request_for_wiki_deletion). For the latter, this is clean up following the wiki's deletion last winter per Dormancy Policy