### PR TITLE
Allow zealandiawiki to import templates from wikia:adoriasim

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1714,6 +1714,11 @@ $wi->config->settings += [
 				'it',
 			],
 		],
+		'+zealandiawiki' => [
+			'wikia' => [
+				'adoriasim',
+			],
+		],
 		'+zhwpwikiwiki' => [
 			'zhwp',
 		],


### PR DESCRIPTION
`$wgImportSources` doesn't seem to be in any of the ManageWiki pages