### PR TITLE
Update "Hosted by Miraheze" web badge

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1241,7 +1241,7 @@ $wi->config->settings += [
 				'miraheze' => [
 					'src' => "https://$wmgUploadHostname/commonswiki/f/ff/Powered_by_Miraheze.svg",
 					'url' => 'https://meta.miraheze.org/wiki/Special:MyLanguage/Miraheze',
-					'alt' => 'Powered by Miraheze'
+					'alt' => 'Hosted by Miraheze'
 				]
 			]
 		]

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1239,9 +1239,9 @@ $wi->config->settings += [
 		'default' => [
 			'poweredby' => [
 				'miraheze' => [
-					'src' => "https://$wmgUploadHostname/metawiki/7/7e/Powered_by_Miraheze.png",
+					'src' => "https://$wmgUploadHostname/commonswiki/f/ff/Powered_by_Miraheze.svg",
 					'url' => 'https://meta.miraheze.org/wiki/Special:MyLanguage/Miraheze',
-					'alt' => 'Miraheze Wiki Hosting'
+					'alt' => 'Powered by Miraheze'
 				]
 			]
 		]


### PR DESCRIPTION
Per [this](https://meta.miraheze.org/wiki/Requests_for_Comment/Changing_the_Powered_by_Miraheze_footer_button) recently closed RfC, the community has chosen this image to replace the current web badge.