### PR TITLE
Configure `$wgRemovePIIAllowedWikis`

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3305,6 +3305,13 @@ $wi->config->settings += [
 	'wgRemovePIIHashPrefix' => [
 		'default' => 'MirahezeGDPR_',
 	],
+	'wgRemovePIIAllowedWikis' => [
+		'default' => [
+			'loginwiki',
+			'metawiki',
+			'test3wiki',
+		],
+	],
 
 	// ReplaceText
 	'wgReplaceTextResultsLimit' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3307,7 +3307,6 @@ $wi->config->settings += [
 	],
 	'wgRemovePIIAllowedWikis' => [
 		'default' => [
-			'loginwiki',
 			'metawiki',
 			'test3wiki',
 		],


### PR DESCRIPTION
Only allows Special:RemovePII to be used from `metawiki` and `test3wiki`, but it still runs jobs on all wikis.