### PR TITLE
Set `beta` cluster to c3 / db12, where `test3wiki` is located

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -43,7 +43,7 @@ $wi->config->settings['wgLBFactoryConf']['default'] = [
 			'db11' => 1, // should echo c1
 		],
 		'beta' => [
-			'db11' => 1, // should echo c1 (for now)
+			'db12' => 1, // should echo c3 (where test3wiki is located)
 		],
 	],
 	'readOnlyBySection' => [


### PR DESCRIPTION
On test3:
* `$wgEchoSharedTrackingDB` is set to `test3wiki`.
* `$wgEchoSharedTrackingCluster` is set to the `beta` cluster. This tells what cluster for `$wgEchoSharedTrackingDB` to look for the database on.
* the `beta` cluster is set to c1, which is db11, while the `test3wiki` database is located on db12/c3, so it can't find it on db11.

This is resulting in continuous database errors on test3.