### PR TITLE
Re-add extendedconfirmed protection level to lhmnwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3372,6 +3372,7 @@ $wi->config->settings += [
 		],
 		'+lhmnwiki' => [
 			'editqualityarticles',
+			'editextendedconfirmedprotected',
 		],
 		'+memeswiki' => [
 			'editextendedconfirmedprotected',
@@ -3450,6 +3451,7 @@ $wi->config->settings += [
 		],
 		'lhmnwiki' => [
 			'editqualityarticles',
+			'editextendeconfirmedprotected',
 		],
 		'memeswiki' => [
 			'editextendedconfirmedprotected',


### PR DESCRIPTION
Per request (https://meta.miraheze.org/w/index.php?title=Stewards%27_noticeboard&diff=214165&oldid=214148&diffmode=source) at stewards' noticeboard, mainly to allow the user to edit previously protected pages as `editextendedconfirmedprotected`. The user //may// subsequently request to re-remove this protection level, or they may just keep it as an unused protection level