### PR TITLE
LS: remove `$wgAbuseFilterRestrictions`

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -97,14 +97,6 @@ $wi->config->settings += [
 	'wgAbuseFilterAnonBlockDuration' => [
 		'default' => 2592000,
 	],
-	'wgAbuseFilterActionRestrictions' => [
-		'default' => [
-			'blockautopromote' => true,
-			'block' => true,
-			'degroup' => true,
-			'rangeblock' => true,
-		],
-	],
 	'wgAbuseFilterNotifications' => [
 		'default' => 'udp',
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -97,7 +97,7 @@ $wi->config->settings += [
 	'wgAbuseFilterAnonBlockDuration' => [
 		'default' => 2592000,
 	],
-	'wgAbuseFilterRestrictions' => [
+	'wgAbuseFilterActionRestrictions' => [
 		'default' => [
 			'blockautopromote' => true,
 			'block' => true,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -88,7 +88,7 @@ $wgManageWikiSettings = [
 			'warn' => true,
 		],
 		'section' => 'anti-spam',
-		'help' => 'The possible actions that can be taken by abuse filters. When adding a new action, check if it is restricted in $wgAbuseFilterRestrictions and, if it is, don\'t forget to add the abusefilter-modify-restricted right to the appropriate user groups.',
+		'help' => 'The possible actions that can be taken by abuse filters. When adding a new action, check if it is restricted in <code>$wgAbuseFilterActionRestrictions</code> and, if it is, don\'t forget to add the abusefilter-modify-restricted right to the appropriate user groups.',
 		'requires' => [],
 	],
 	'wgAutoblockExpiry' => [


### PR DESCRIPTION
1) This is wrongly named
2) This is set as the default for `$AbuseFilterActionRestrictions`, the new configuration name. No need to explicitly set.