### PR TITLE
Reset FlaggedRevs config defaults to extension defaults

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1147,59 +1147,27 @@ $wi->config->settings += [
 	],
 	'wgFlaggedRevsTags' => [
 		'default' => [
-			'status' => [
-				'levels' => 2,
+			'accuracy' => [
+				'levels' => 3,
+				'quality' => 2,
+				'pristine' => 4,
 			],
 		],
 		'infectopedwiki' => [
 			'accuracy' => [
 				'levels' => 4,
+				'quality' => 2,
+				'pristine' => 4,
 			],
 		],
-		'isvwiki' => [
+		'+isvwiki' => [
 			'status' => [
 				'levels' => 1,
 			],
 		],
 	],
-	'wgFlaggedRevsTagsRestrictions' => [
-		'default' => [
-			'status' => [
-				'review' => 1,
-				'autoreview' => 1,
-			],
-		],
-	],
-	'wgFlaggedRevsTagsAuto' => [
-		'default' => [
-			'status' => 1,
-		],
-	],
-	'wgFlaggedRevsAutopromote' => [
-		'default' => [
-			'days' => 14,
-			'edits' => 100,
-			'excludeLastDays' => 1,
-			'benchmarks' => 1,
-			'spacing' => 1,
-			'totalContentEdits' => 100,
-			'totalCheckedEdits' => 100,
-			'uniqueContentPages' => 10,
-			'editComments' => 80,
-			'userpageBytes' => 1,
-			'neverBlocked' => true,
-			'maxRevertedEditRatio' => 0.05,
-		],
-		'isvwiki' => false,
-	],
 	'wgFlaggedRevsAutoReview' => [
 		'default' => 3,
-	],
-	'wgFlaggedRevsRestrictionLevels' => [
-		'default' => [
-			'',
-			'sysop'
-		],
 	],
 	'wgSimpleFlaggedRevsUI' => [
 		'default' => true,


### PR DESCRIPTION
* Current configuration breaks i18n. Only accuracy seems to have i18n within FlaggedRevs, not doing this means we need to at least add custom i18n to MirahezeMagic.
* With the FlaggedRevs simplification, we don't need to keep up with it quite as much with this.
* Removes unnecessary configs which means they become default automatically, simplifying our configuration.