### PR TITLE
set ManageWikiNamespaces' variable defaults

### DIFF
--- a/Defines.php
+++ b/Defines.php
@@ -234,6 +234,10 @@ $wi->config->settings['wgDataDump']['default'] = [
 
 // set ManageWikiNamespaces' variable defaults
 foreach ( array_keys( $wgManageWikiNamespacesAdditional ) as $var ) {
+	if ( isset( $wgManageWikiNamespacesAdditional[$var]['whitelisted'] ) ) {
+		continue;
+	}
+
 	if ( !isset( ${$var} ) ) {
 		${$var} = [];
 	}

--- a/Defines.php
+++ b/Defines.php
@@ -232,9 +232,11 @@ $wi->config->settings['wgDataDump']['default'] = [
 	],
 ];
 
-// Exempt from Robot Control (INDEX/NOINDEX namespaces)
-if ( !isset( $wgExemptFromUserRobotsControl ) ) {
-	$wgExemptFromUserRobotsControl = [];
+// set ManageWikiNamespaces' variable defaults
+foreach ( array_keys( $wgManageWikiNamespacesAdditional ) as $var ) {
+	if ( !isset( ${$var} ) ) {
+		${$var} = [];
+	}
 }
 
 // $wmgContactPageRecipientUser


### PR DESCRIPTION
To fix issues like [T8504](https://phabricator.miraheze.org/T8504).

If these defaults were set like normal via LS then until changes they would not be on any namespaces. This sets defaults to disable on all namespaces, if they are disabled on every namespace via ManageWikiNamespaces, to prevent that from reverting them to the extension-set defaults.