### PR TITLE
Add `$wgDarkModeTogglePosition` to ManageWikiSettings

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1030,6 +1030,11 @@ $wi->config->settings += [
 		'default' => '/srv/GeoLite2-City.mmdb',
 	],
 
+	// Darkmode
+	'wgDarkModeTogglePosition' => [
+		'default' => 'personal',
+	],
+
 	// Database
 	'wgAllowSchemaUpdates' => [
 		'default' => false,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3164,6 +3164,20 @@ $wgManageWikiSettings = [
 		'help' => 'Watch and unwatch as an icon rather than a link.',
 		'requires' => [],
 	],
+	'wgDarkModeTogglePosition' => [
+		'name' => 'Dark mode toggle link position',
+		'from' => 'darkmode',
+		'type' => 'list',
+		'options' => [
+			'Next to the user talk page link in personal URLs' => 'personal',
+			'In the footer, usually after the "Disclaimer" link.' => 'footer',
+			'In the sidebar within the navigation portlet.' => 'sidebar',
+		],
+		'overridedefault' => 'personal',
+		'section' => 'styling',
+		'help' => 'Where the dark mode toggle link should be placed.',
+		'requires' => [],
+	],
 
 	// Wikibase
 	'wmgWikibaseRepoUrl' => [


### PR DESCRIPTION
- **Motivation**: It makes the admin be able to avoid https://phabricator.wikimedia.org/T297353 (DarkMode toggle as a personal tool on new Vector is misaligned) by setting the value to `'footer'`.
- **Attachment**:
  ![image](https://user-images.githubusercontent.com/28209361/147877263-14445839-f1db-4b32-bf65-7479044fc7f7.png)
