### PR TITLE
Fix sitenotice; escape $

### DIFF
--- a/Sitenotice.php
+++ b/Sitenotice.php
@@ -38,7 +38,7 @@ if ( $wgUseCategoryBrowser ?? true ) {
 
 		$siteNotice .= <<<EOF
 				<div data-nosnippet><table class="wikitable" style="text-align:center;"><tbody><tr>
-				<td style="font-size:125%">MediaWiki developers are considering removing <a href="https://www.mediawiki.org/wiki/Manual:$wgUseCategoryBrowser">Category Browser ($wgUseCategoryBrowser)</a>. <b>Miraheze is requesting your feedback on this so we can forward it to MediaWiki developers!</b> Let us know what you think <a href="https://meta.miraheze.org/wiki/Community_noticeboard#Request_for_Feedback:_Removal_of_$wgUseCategoryBrowser_in_MediaWiki_1.38">here</a>.</td>
+				<td style="font-size:125%">MediaWiki developers are considering removing <a href="https://www.mediawiki.org/wiki/Manual:&#36;wgUseCategoryBrowser">Category Browser (&#36;wgUseCategoryBrowser)</a>. <b>Miraheze is requesting your feedback on this so we can forward it to MediaWiki developers!</b> Let us know what you think <a href="https://meta.miraheze.org/wiki/Community_noticeboard#Request_for_Feedback:_Removal_of_$wgUseCategoryBrowser_in_MediaWiki_1.38">here</a>.</td>
 				</tr></tbody></table></div>
 		EOF;
 	}


### PR DESCRIPTION
Changes $ to &#36; to properly escape the character and fix the sitenotice not displaying the link properly