### PR TITLE
Enable more caching

### DIFF
--- a/GlobalCache.php
+++ b/GlobalCache.php
@@ -12,7 +12,7 @@ $wgLanguageConverterCacheType = CACHE_ACCEL;
 $wgParserCacheExpireTime = 86400 * 10;
 $wgDLPQueryCacheTime = 120;
 
-$wgEnableSidebarCache = true;
+$wgEnableSidebarCache = false;
 $wgUseLocalMessageCache = true;
 $wgInvalidateCacheOnLocalSettingsChange = false;
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -294,19 +294,10 @@ $wi->config->settings += [
 		],
 	],
 	'wgPreprocessorCacheThreshold' => [
-		'default' => false,
-	],
-	'wgResourceLoaderMaxage' => [
-		'default' => [
-			'versioned' => 12 * 60 * 60,
-			'unversioned' => 5 * 60,
-		],
+		'default' => 2000,
 	],
 	'wgRevisionCacheExpiry' => [
-		'default' => 0,
-	],
-	'wgEnableSidebarCache' => [
-		'default' => false,
+		'default' => 86400 * 2, // 2 days
 	],
 
 	// Captcha


### PR DESCRIPTION
* set `$wgResourceLoaderMaxage` to default (by removing it being declared here)
* set `$wgRevisionCacheExpiry` to 2 days
* set `$wgPreprocessorCacheThreshold` to 2000