### PR TITLE
Define constraints for various strings

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -127,6 +127,21 @@ if ( $wgDBname === 'gratisdatawiki' ) {
 			],
 		],
 	];
+	// Define constraints for various strings, such as multilingual terms (such as labels, descriptions and aliases).
+	$wgWBRepoSettings['string-limits'] = [
+		'multilang' => [
+			'length' => 250, // length constraint
+		],
+		'VT:monolingualtext' => [
+			'length' => 400,
+		],
+		'VT:string' => [
+			'length' => 400,
+		],
+		'PT:url' => [
+			'length' => 500,
+		],
+	];
 }
 
 if ( $wgDBname === 'gratispaideiawiki' ) {


### PR DESCRIPTION
They're all currently on 250 limit which cause issues when adding long aliases or description or even URL slugs.