### PR TITLE
T8932: ApprovedRevs configs

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -217,6 +217,14 @@ $wi->config->settings += [
 	'egApprovedRevsAutomaticApprovals' => [
 		'default' => true,
 	],
+	'egApprovedRevsShowApproveLatest' => [
+		'default' => null,
+		'primalfeararkwiki' => true,
+	],
+	'egApprovedRevsShowNotApprovedMessage' => [
+		'default' => null,
+		'primalfeararkwiki' => true,
+	],
 
 	// ArticleCreationWorkflow
 	'wgArticleCreationLandingPage' => [


### PR DESCRIPTION
Should I set the defaults? (I didn't because it's not available from managewiki) or It is better this way (setting it per wiki)?