### PR TITLE
Revert "Adding missing Mobilefrontend configs (#4499)"

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2935,8 +2935,6 @@ $wi->config->settings += [
 	],
 	'wgMFNoindexPages' => [
 		'wmgUseMobileFrontend' => false,
-		'gratisdatawiki' => true,
-		'gratispaideiawiki' => true,
 	],
 	'wgMFStopRedirectCookieHost' => [
 		'wmgUseMobileFrontend' => $wi->hostname,
@@ -2976,85 +2974,6 @@ $wi->config->settings += [
 			'beta' => true,
 			'amc' => true,
 		],
-	],
-	'wgMFUseWikibase' => [
-		'default' => false,
-		'gratispaideiawiki' => true,
-		'gratisdatawiki' => true,
-	],
-	'wgMFDisplayWikibaseDescriptions' => [
-		'default' => [
-			'search' => true,
-			'nearby' => true,
-			'watchlist' => true,
-			'tagline' => true,
-		],
-		'gratispaideiawiki' => [
-			'search' => true,
-			'nearby' => true,
-			'watchlist' => true,
-			'tagline' => false,
-		],
-	],
-	'wgMFMobileFormatterOptions' => [
-		'default' => [],
-		'gratispaideiawiki' => [
-			'excludeNamespaces' => [
-				10, 
-				-1,
-			],
-			'maxImages' => 1000,
-			'maxHeadings' => 4000,
-			'headings' => [ 
-				'h1', 
-				'h2', 
-				'h3', 
-				'h4', 
-				'h5', 
-				'h6', 
-			],
-		],
-	],
-	'wgMFNearby' => [
-		'default' => false, 
-		'gratispaideiawiki' => true, 
-		'gratisdatawiki' => true,
-	],
-	'wmgUseMobileApp' => [
-		'default' => false,
-		'gratispaideiawiki' => true,
-		'gratisdatawiki' => true,
-	],
-	'wgMFQueryPropModules' => [
-		'default' => [ 
-			'pageprops', 
-		],
-		'gratisdatawiki' => [ 
-			'entityterms',
-		],
-	],
-	'wgMFSearchAPIParams' => [
-		'default' => [
-			'ppprop' => 'displaytitle',
-		],
-		'gratisdatawiki' => [
-			'wbetterms' => 'label',
-		],
-	],
-	'wgMFSearchGenerator' => [
-		'default' => [
-			'name' => 'prefixsearch',
-			'prefix' => 'ps',
-		],
-		'gratisdatawiki' => [
-			'name' => 'wbsearch',
-			'prefix' => 'wbs',
-		],
-	],
-	'wgMFNamespacesWithLeadParagraphs' => [
-		'default' => [],
-		'gratispaideiawiki' => [ NS_MAIN ],
-		'gratisdatawiki' => [ NS_MAIN ],
 	],
 
 	// Moderation extension settings


### PR DESCRIPTION
This reverts commit 08f0e1d.

* Likely causes https://phabricator.miraheze.org/T8962.
* `$wgMFDisplayWikibaseDescriptions`, `$wgMFMobileFormatterOptions`, and `$wgMFNamespacesWithLeadParagraphs` defaults are wrong.
* Support for geodata is likely not even possible with Miraheze, and if it does actually work I still have concerns about it.
* `pageprops` still needs to be present for `$wgMFQueryPropModules` for `gratisdatawiki` likely.
* `'ppprop' => 'displaytitle',` still needs to be present for `$wgMFSearchAPIParams` for `gratisdatawiki` likely.
* The defaults for `$wgMFSearchGenerator` still need to be present for `gratisdatawiki` likely.
* `$wmgUseMobileApp` doesn't even exist.