### PR TITLE
Disallow `centralauth-suppress` right in ManageWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2572,6 +2572,7 @@ $wi->config->settings += [
 				'centralauth-createlocal',
 				'centralauth-lock',
 				'centralauth-oversight',
+				'centralauth-suppress',
 				'centralauth-rename',
 				'centralauth-unmerge',
 				'centralauth-usermerge',


### PR DESCRIPTION
Renamed from centralauth-oversight in 1.38, this can be done whenever, even before 1.38.