### PR TITLE
Update Wikibase.php

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -196,7 +196,7 @@ if ( $wgDBname === 'gratispaideiawiki' ) {
 	];
 	$wgWBClientSettings['allowLocalShortDesc'] = true;
 	$wgWBClientSettings['forceLocalShortDesc'] = true;
-	$wgWBClientSettings['allowDataTransclusion'] = true;
+	$wgWBClientSettings['showExternalRecentChanges'] = true;
 }
 if ( $wgDBname === 'benpediawiki' ) {
 	$wgWBClientSettings['repoSiteName'] = 'Gratisdata';

--- a/Wikibase.php
+++ b/Wikibase.php
@@ -196,7 +196,6 @@ if ( $wgDBname === 'gratispaideiawiki' ) {
 	];
 	$wgWBClientSettings['allowLocalShortDesc'] = true;
 	$wgWBClientSettings['forceLocalShortDesc'] = true;
-	$wgWBClientSettings['showExternalRecentChanges'] = true;
 }
 if ( $wgDBname === 'benpediawiki' ) {
 	$wgWBClientSettings['repoSiteName'] = 'Gratisdata';

--- a/Wikibase.php
+++ b/Wikibase.php
@@ -140,6 +140,36 @@ if ( $wgDBname === 'gratisdatawiki' ) {
 		],
 	];
 	$wgWBRepoSettings['allowEntityImport'] = false;
+	$wgWBRepoSettings['preferredPageImagesProperties'] = [
+		// Photos
+		'P386',
+		'P520',
+		'P521',
+		'P522',
+		'P523',
+		'P524',
+		// Complex graphics
+		'P135',
+		'P136',
+		'P387',
+		'P525',
+		// Simple graphics
+		'P526',
+		'P527',
+		'P528',
+		'P470',
+		'P529',
+		// Multi page content
+		'P530',
+		// Maps
+		'P531',
+		'P327',
+		'P532',
+		'P533',
+	];
+	$wgWBRepoSettings['preferredGeoDataProperties'] = [
+		'P134',
+	];
 }
 
 if ( $wgDBname === 'gratispaideiawiki' ) {
@@ -160,6 +190,13 @@ if ( $wgDBname === 'gratispaideiawiki' ) {
 	$wgWBClientSettings['linkItemTags'] = [
 		'client-linkitem-change'
 	];
+	$wgWBClientSettings['sendEchoNotification'] = true;
+	$wgWBClientSettings['echoIcon'] = [
+		'url' => 'https://static.miraheze.org/commonswiki/a/a4/GDechoIcon.svg',
+	];
+	$wgWBClientSettings['allowLocalShortDesc'] = true;
+	$wgWBClientSettings['forceLocalShortDesc'] = true;
+	$wgWBClientSettings['allowDataTransclusion'] = true;
 }
 if ( $wgDBname === 'benpediawiki' ) {
 	$wgWBClientSettings['repoSiteName'] = 'Gratisdata';


### PR DESCRIPTION
Please merge appropriately after reviewing. Find my explanation for each variable below per @Universal-Omega

### preferredPageImagesProperties
The property IDs listed here are those that should be considered for the page property `page_image`.
### preferredGeoDataProperties
The only difference is that the properties listed here are taken into account when determining primary coordinates for the GeoData extension on an entity.
### sendEchoNotification
As I set this to true, users on gratispaideia and/or any other client wiki will be notified when a page they created is linked to a repository item.
### echoIcon
This one is related to the `sendEchoNotification`; it only has an effect when it is set to true, otherwise, it is ineffectual. It is the icon that will be visible along with the message when the alert is sent to the user.
### allowLocalShortDesc
Setting this to true will enable local override of the central description with the `{{SHORTDESC:}}` parser function. Just for a note; the central description is the description that is added to the wikibase item. So Instead of displaying that setting this to true will make it display the short description of the article.
### forceLocalShortDesc
This one simply forces it, when it's refusing by any chance