### PR TITLE
WBQuality constraint configs for gratisdatawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4386,6 +4386,34 @@ $wi->config->settings += [
 	'wgWBQualityConstraintsSubclassOfId' => [
 		'default' => 'P279',
 	],
+	'wgWBQualityConstraintsStartTimePropertyIds' => [
+		'default' => [
+			'P569',
+			'P571',
+			'P580',
+			'P585',
+		],
+		'gratisdatawiki' => [
+			'P26',
+			'P11',
+			'P174',
+			'P80',
+		],
+	],
+	'wgWBQualityConstraintsEndTimePropertyIds' => [
+		'default' => [
+			'P570',
+			'P576',
+			'P582',
+			'P585',
+		],
+		'gratisdatawiki' => [
+			'P132',
+			'P539',
+			'P175',
+			'P80',
+		],
+	],
 	'wgWBQualityConstraintsPropertyConstraintId' => [
 		'default' => 'P2302',
 	],


### PR DESCRIPTION
These variables aren't available from ManageWiki, and If it should be added to managewiki, it is going to be possible to add more than one value?
So, please review and merge appropriately.