### PR TITLE
T8874: Add the otherProjectsLink on gratispaideiawiki

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -160,6 +160,12 @@ if ( $wgDBname === 'gratispaideiawiki' ) {
 	$wgWBClientSettings['linkItemTags'] = [
 		'client-linkitem-change'
 	];
+	$wgWBClientSettings['otherProjectsLinks'] = [
+		'gratisdatawiki',
+		'metawiki',
+		'commonswiki',
+		'benpediawiki',
+	];
 }
 if ( $wgDBname === 'benpediawiki' ) {
 	$wgWBClientSettings['repoSiteName'] = 'Gratisdata';


### PR DESCRIPTION
Per my comment [here](https://phabricator.miraheze.org/T8874#182273), an empty or non-existent otherProjectsLinks variable suppresses the Other projects section on the sidebar.
If this works as intended then we have to tweak it in a way that it will be able to show all site IDs in the `miraheze` `siteLinkGroups ` without needing to list a thousand wikis.