### PR TITLE
Update Wikibase.php with siteLinkGroups for gratisdatawiki

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -175,6 +175,10 @@ if ( $wgDBname === 'gratisdatawiki' ) {
 	$wgWBRepoSettings['preferredGeoDataProperties'] = [
 		'P134',
 	];
+	$wgWBRepoSettings['siteLinkGroups'] = [
+		'miraheze',
+		'gratispaideia'
+	];
 }
 
 if ( $wgDBname === 'gratispaideiawiki' ) {


### PR DESCRIPTION
There is a lot of explanation for this, actually. So, I'm going to try and see if I can explain them concisely.
After this is merged there are two more variables that needs to be set; `languageLinkSiteGroup` and  `languageLinkAllowedSiteGroups`, but before then:

This gratispaidea siteLinkGroup would be the site group for the various language wikis, currently two (gratispaideiawiki (English) and benpediawiki (Spanish)).
So, when we now have the gratispaideia site group, we will be able to set `languageLinkSiteGroup` with a `gratispaideia` value. 

Currently you'd observe that, in the `Languages` sidebar section, we have all the site listed in the `miraheze` site group. Let me explain that behaviour, The reason that happens is that the default value for `languageLinkSiteGroup` is `null`, which means it will fallback to the site's own site group, which is the `miraheze` site group and that is why we currently have sites listed in the miraheze site group on the `Languages` sidebar. When this is merged and we now have `gratispaideia` site group, and then we set the value of `languageLinkSiteGroup` to gratispaideia, then only the sites listed under gratispaideia site group would be listed on the `Languages` sidebar. 
And that is, despite we have set other project link, we still don't have it appearing.

There is also `languageLinkAllowedSiteGroups`, this one is for when we want to display multiple language sitegroups on the sidebar, the default for this is `null` which means it will fall back to the value of `languageLinkSiteGroup`, which is totally okay.