### PR TITLE
Update Wikibase.php with repoSiteName for gratispaideiawiki

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -209,6 +209,7 @@ if ( $wgDBname === 'gratispaideiawiki' ) {
 		'commonswiki',
 		'benpediawiki',
 	];
+	$wgWBClientSettings['repoSiteId'] = 'gratisdatawiki';
 }
 
 if ( $wgDBname === 'benpediawiki' ) {


### PR DESCRIPTION
I'm setting this to `gratisdatawiki` value, because I just realised that the default value for this is to assume both client and repo are the same, or if for example we set `siteGlobalID`, either ways, it returns `gratispaideiawiki` (self) instead of the original repo global ID.