### PR TITLE
set recaptcha v3 minimum score to 0.3 from 0.5 [TRIAL]

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -369,6 +369,9 @@ $wi->config->settings += [
 	'wgReCaptchaVersion' => [
 		'default' => 'v3',
 	],
+	'wgReCaptchaMinimumScore' => [
+		'default' => 0.3,
+	],
 
 	// Cargo
 	'wgCargoDBuser' => [


### PR DESCRIPTION
Since there is clearly no progress on ReCaptcha enterprise or investigating into detail, I propose we set the score to 0.3 for 12 hours and observe what the effects are - are spambots getting in? are there no more form entries? etc. I feel that most users getting turned away get 0.3 while spambots get 0.1

@RhinosF1 @MacFan4000 @Universal-Omega thoughts?