### PR TITLE
test: Validate ManageWikiSettings.php file

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -174,7 +174,7 @@ $wgManageWikiSettings = [
 		'from' => 'protectsite',
 		'type' => 'list',
 		'options' => [
-			'Indefinite' => 'indefinite',
+			'indefinite' => 'indefinite',
 			'10 year' => '10 year',
 			'1 week' => '1 week',
 		],
@@ -971,7 +971,7 @@ $wgManageWikiSettings = [
 		'from' => 'translate',
 		'type' => 'list',
 		'options' => [
-			'Info' => 'info',
+			'info' => 'info',
 			'No Documentation' => false,
 			'qqq' => 'qqq',
 		],
@@ -1241,7 +1241,7 @@ $wgManageWikiSettings = [
 		'type' => 'check',
 		'overridedefault' => true,
 		'section' => 'media',
-		'help' => 'Only load the iframe if the user clicks it?',
+		'help' => 'Only load the iframe if the user clicks it?',
 		'requires' => [],
 	],
 	'wgRPUseMMVModule' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -174,7 +174,7 @@ $wgManageWikiSettings = [
 		'from' => 'protectsite',
 		'type' => 'list',
 		'options' => [
-			'indefinite' => 'indefinite',
+			'Indefinite' => 'indefinite',
 			'10 year' => '10 year',
 			'1 week' => '1 week',
 		],
@@ -971,7 +971,7 @@ $wgManageWikiSettings = [
 		'from' => 'translate',
 		'type' => 'list',
 		'options' => [
-			'info' => 'info',
+			'Info' => 'info',
 			'No Documentation' => false,
 			'qqq' => 'qqq',
 		],

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
 			"parallel-lint . --exclude node_modules --exclude vendor",
 			"minus-x check .",
 			"@phpcs",
-			"@phpunit"
+			"@phpunit ./tests"
 		],
 		"phpcs": "phpcs -sp --cache",
-		"phpunit": "phpunit ./tests"
+		"phpunit": "phpunit"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,14 @@
 		"mediawiki/mediawiki-codesniffer": "38.0.0",
 		"mediawiki/minus-x": "1.1.1",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
-		"php-parallel-lint/php-parallel-lint": "1.3.2"
+		"php-parallel-lint/php-parallel-lint": "1.3.2",
+		"phpunit/phpunit": "^8.5",
+		"justinrainbow/json-schema": "5.2.11"
+	},
+	"autoload": {
+		"psr-4": {
+			"Miraheze\\Tests\\": "tests/"
+		}
 	},
 	"scripts": {
 		"fix": [
@@ -15,8 +22,10 @@
 		"test": [
 			"parallel-lint . --exclude node_modules --exclude vendor",
 			"minus-x check .",
-			"@phpcs"
+			"@phpcs",
+			"@phpunit"
 		],
-		"phpcs": "phpcs -sp --cache"
+		"phpcs": "phpcs -sp --cache",
+		"phpunit": "phpunit ./tests"
 	}
 }

--- a/tests/ManageWiki/ManageWikiTestCase.php
+++ b/tests/ManageWiki/ManageWikiTestCase.php
@@ -8,6 +8,8 @@ use stdClass;
 
 abstract class ManageWikiTestCase extends TestCase {
 
+	public const REGEX_READABLE = '^[A-Za-z0-9 _,;:!?“”(){}*/&#<=>|\.\'\"\[\]\$-]+$';
+
 	abstract public function getSchema(): array;
 
 	public function mockConfig(): stdClass {

--- a/tests/ManageWiki/ManageWikiTestCase.php
+++ b/tests/ManageWiki/ManageWikiTestCase.php
@@ -8,6 +8,8 @@ use stdClass;
 
 abstract class ManageWikiTestCase extends TestCase {
 
+	abstract public function getSchema(): array;
+
 	public function mockConfig(): stdClass {
 		$mock = $this->getMockBuilder( stdClass::class )
 			->addMethods( [ 'get' ] )
@@ -17,9 +19,9 @@ abstract class ManageWikiTestCase extends TestCase {
 		return $mock;
 	}
 
-	public function assertSchema( $config, $schema ) {
+	public function assertSchema( $config ) {
 		$validator = new Validator();
-		$validator->validate( $config, $schema );
+		$validator->validate( $config, $this->getSchema() );
 
 		$this->assertTrue(
 			$validator->isValid(),
@@ -30,9 +32,9 @@ abstract class ManageWikiTestCase extends TestCase {
 	abstract public function configProvider(): array;
 
 	/** @dataProvider configProvider */
-	public function testScheme( $config, $schema, $expected ) {
+	public function testScheme( $config, $expected ) {
 		$validator = new Validator();
-		$validator->validate( $config, $schema );
+		$validator->validate( $config, $this->getSchema() );
 
 		$this->assertSame(
 			$expected,

--- a/tests/ManageWiki/ManageWikiTestCase.php
+++ b/tests/ManageWiki/ManageWikiTestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Miraheze\Tests\ManageWiki;
+
+use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+abstract class ManageWikiTestCase extends TestCase {
+
+	public function mockConfig(): stdClass {
+		$mock = $this->getMockBuilder( stdClass::class )
+			->addMethods( [ 'get' ] )
+			->getMock();
+		$mock->method( 'get' )->willReturn( false );
+
+		return $mock;
+	}
+
+	public function assertSchema( $config, $schema ) {
+		$validator = new Validator();
+		$validator->validate( $config, $schema );
+
+		$this->assertTrue(
+			$validator->isValid(),
+			self::readableError( $validator->getErrors() )
+		);
+	}
+
+	abstract public function configProvider(): array;
+
+	/** @dataProvider configProvider */
+	public function testScheme( $config, $schema, $expected ) {
+		$validator = new Validator();
+		$validator->validate( $config, $schema );
+
+		$this->assertSame(
+			$expected,
+			$validator->isValid(),
+			self::readableError( $validator->getErrors() )
+		);
+	}
+
+	public static function readableError( array $errors ): string {
+		$msgs = [];
+		foreach ( $errors as $err ) {
+			$msgs[] = "[{$err['property']}] {$err['message']}";
+		}
+		return implode( "\n", $msgs );
+	}
+
+}

--- a/tests/ManageWiki/ManageWikiTestCase.php
+++ b/tests/ManageWiki/ManageWikiTestCase.php
@@ -36,7 +36,6 @@ abstract class ManageWikiTestCase extends TestCase {
 
 		$this->assertSame(
 			$expected,
-			$validator->isValid(),
 			self::readableError( $validator->getErrors() )
 		);
 	}

--- a/tests/ManageWiki/ManageWikiTestCase.php
+++ b/tests/ManageWiki/ManageWikiTestCase.php
@@ -27,24 +27,24 @@ abstract class ManageWikiTestCase extends TestCase {
 
 		$this->assertTrue(
 			$validator->isValid(),
-			self::readableError( $validator->getErrors() )
+			self::readableErrors( $validator->getErrors() )
 		);
 	}
 
 	abstract public function configProvider(): array;
 
 	/** @dataProvider configProvider */
-	public function testScheme( $config, $expected ) {
+	public function testGetScheme( $config, $expected ) {
 		$validator = new Validator();
 		$validator->validate( $config, $this->getSchema() );
 
 		$this->assertSame(
 			$expected,
-			self::readableError( $validator->getErrors() )
+			self::readableErrors( $validator->getErrors() )
 		);
 	}
 
-	public static function readableError( array $errors ): string {
+	private static function readableErrors( array $errors ): string {
 		$msgs = [];
 		foreach ( $errors as $err ) {
 			$msgs[] = "[{$err['property']}] {$err['message']}";

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -7,7 +7,7 @@ class SettingsTest extends ManageWikiTestCase {
 		'type' => 'array',
 		'additionalProperties' => false,
 		'patternProperties' => [
-			'^(wg|eg|wmg)[a-zA-Z_][a-zA-Z0-9_]*$' => [
+			'^(wg|eg|wmg)[A-Z_][a-zA-Z0-9_]*$' => [
 				'type' => 'array',
 				'additionalProperties' => false,
 				'properties' => [

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -3,111 +3,113 @@
 namespace Miraheze\Tests\ManageWiki;
 
 class SettingsTest extends ManageWikiTestCase {
-	public const SCHEMA = [
-		'type' => 'array',
-		'additionalProperties' => false,
-		'patternProperties' => [
-			'^(wg|eg|wmg)[A-Z_][a-zA-Z0-9_]*$' => [
-				'type' => 'array',
-				'additionalProperties' => false,
-				'properties' => [
-					'name' => [
-						'type' => 'string',
-						'required' => true,
-					],
-					'from' => [
-						'type' => 'string',
-						'required' => true,
-					],
-					'global' => [
-						'type' => 'boolean',
-					],
-					'type' => [
-						'type' => 'string',
-						'enum' => [
-							'check',
-							'database',
-							'integer',
-							'integers',
-							'list-multi-bool',
-							'list-multi',
-							'list',
-							'preferences',
-							'skin',
-							'skins',
-							'text',
-							'texts',
-							'timezone',
-							'url',
-							'user',
-							'usergroups',
-							'users',
-							'wikipage',
-							'wikipages',
-						],
-						'required' => true,
-					],
-					'exists' => [
-						'type' => 'boolean',
-					],
-					'allopts' => [
-						'type' => 'array',
-						'additionalProperties' => false,
-						'items' => [
+	public function getSchema(): array {
+		return [
+			'type' => 'array',
+			'additionalProperties' => false,
+			'patternProperties' => [
+				'^(wg|eg|wmg)[A-Z_][a-zA-Z0-9_]*$' => [
+					'type' => 'array',
+					'additionalProperties' => false,
+					'properties' => [
+						'name' => [
 							'type' => 'string',
+							'required' => true,
 						],
-					],
-					'options' => [
-						'type' => 'array',
-					],
-					'minint' => [
-						'type' => 'integer',
-					],
-					'maxint' => [
-						'type' => 'integer',
-					],
-					'overridedefault' => [
-						'required' => true,
-					],
-					'section' => [
-						'type' => 'string',
-						'required' => true,
-					],
-					'help' => [
-						'type' => 'string',
-						'required' => true,
-					],
-					'requires' => [
-						'type' => 'array',
-						'anyOf' => [
-							[
-								'type' => 'array',
-								'patternProperties' => [
-									'extensions' => 'array',
-								],
-							],
-							[
-								'type' => 'array',
-								'items' => [
-									'type' => 'string',
-								],
-							],
+						'from' => [
+							'type' => 'string',
+							'required' => true,
 						],
-					],
-					'script' => [
-						'type' => 'array',
-						'properties' => [
+						'global' => [
+							'type' => 'boolean',
+						],
+						'type' => [
+							'type' => 'string',
+							'enum' => [
+								'check',
+								'database',
+								'integer',
+								'integers',
+								'list-multi-bool',
+								'list-multi',
+								'list',
+								'preferences',
+								'skin',
+								'skins',
+								'text',
+								'texts',
+								'timezone',
+								'url',
+								'user',
+								'usergroups',
+								'users',
+								'wikipage',
+								'wikipages',
+							],
+							'required' => true,
+						],
+						'exists' => [
+							'type' => 'boolean',
+						],
+						'allopts' => [
 							'type' => 'array',
 							'additionalProperties' => false,
-							'patternProperties' => [
-								'update' => 'boolean',
+							'items' => [
+								'type' => 'string',
+							],
+						],
+						'options' => [
+							'type' => 'array',
+						],
+						'minint' => [
+							'type' => 'integer',
+						],
+						'maxint' => [
+							'type' => 'integer',
+						],
+						'overridedefault' => [
+							'required' => true,
+						],
+						'section' => [
+							'type' => 'string',
+							'required' => true,
+						],
+						'help' => [
+							'type' => 'string',
+							'required' => true,
+						],
+						'requires' => [
+							'type' => 'array',
+							'anyOf' => [
+								[
+									'type' => 'array',
+									'patternProperties' => [
+										'extensions' => 'array',
+									],
+								],
+								[
+									'type' => 'array',
+									'items' => [
+										'type' => 'string',
+									],
+								],
+							],
+						],
+						'script' => [
+							'type' => 'array',
+							'properties' => [
+								'type' => 'array',
+								'additionalProperties' => false,
+								'patternProperties' => [
+									'update' => 'boolean',
+								],
 							],
 						],
 					],
 				],
 			],
-		],
-	];
+		];
+	}
 
 	/** @covers $wgManageWikiSettings */
 	public function testManageWikiSettings() {
@@ -121,10 +123,7 @@ class SettingsTest extends ManageWikiTestCase {
 		];
 
 		require_once __DIR__ . '/../../ManageWikiSettings.php';
-		$this->assertSchema(
-			$wgManageWikiSettings,
-			self::SCHEMA
-		);
+		$this->assertSchema( $wgManageWikiSettings );
 	}
 
 	/** @inheritDoc */
@@ -143,7 +142,6 @@ class SettingsTest extends ManageWikiTestCase {
 						'help' => 'Lorem ipsum.',
 					]
 				],
-				self::SCHEMA,
 				''
 			],
 			'An invalid configuration should not be passed the validation.' => [
@@ -152,7 +150,6 @@ class SettingsTest extends ManageWikiTestCase {
 						'type' => 'check',
 					]
 				],
-				self::SCHEMA,
 				implode( "\n", [
 					'[wgAbuseFilterActions.name] The property name is required',
 					'[wgAbuseFilterActions.from] The property from is required',

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Miraheze\Tests\ManageWiki;
+
+class SettingsTest extends ManageWikiTestCase {
+	public const SCHEMA = [
+		'type' => 'array',
+		'additionalProperties' => false,
+		'patternProperties' => [
+			'^(wg|eg|wmg)[a-zA-Z_][a-zA-Z0-9_]*$' => [
+				'type' => 'array',
+				'additionalProperties' => false,
+				'properties' => [
+					'name' => [
+						'type' => 'string',
+						'required' => true,
+					],
+					'from' => [
+						'type' => 'string',
+						'required' => true,
+					],
+					'global' => [
+						'type' => 'boolean',
+					],
+					'type' => [
+						'type' => 'string',
+						'enum' => [
+							'check',
+							'database',
+							'integer',
+							'integers',
+							'list-multi-bool',
+							'list-multi',
+							'list',
+							'preferences',
+							'skin',
+							'skins',
+							'text',
+							'texts',
+							'timezone',
+							'url',
+							'user',
+							'usergroups',
+							'users',
+							'wikipage',
+							'wikipages',
+						],
+						'required' => true,
+					],
+					'exists' => [
+						'type' => 'boolean',
+					],
+					'allopts' => [
+						'type' => 'array',
+						'additionalProperties' => false,
+						'items' => [
+							'type' => 'string',
+						],
+					],
+					'options' => [
+						'type' => 'array',
+					],
+					'minint' => [
+						'type' => 'integer',
+					],
+					'maxint' => [
+						'type' => 'integer',
+					],
+					'overridedefault' => [
+						'required' => true,
+					],
+					'section' => [
+						'type' => 'string',
+						'required' => true,
+					],
+					'help' => [
+						'type' => 'string',
+						'required' => true,
+					],
+					'requires' => [
+						'type' => 'array',
+						'anyOf' => [
+							[
+								'type' => 'array',
+								'patternProperties' => [
+									'extensions' => 'array',
+								],
+							],
+							[
+								'type' => 'array',
+								'items' => [
+									'type' => 'string',
+								],
+							],
+						],
+					],
+					'script' => [
+						'type' => 'array',
+						'properties' => [
+							'type' => 'array',
+							'additionalProperties' => false,
+							'patternProperties' => [
+								'update' => 'boolean',
+							],
+						],
+					],
+				],
+			],
+		],
+	];
+
+	/** @covers $wgManageWikiSettings */
+	public function testManageWikiSettings() {
+		global $wgManageWikiSettings, $IP, $wmgSharedUploadDBname, $wmgUploadHostname, $wgConf, $wi;
+		$IP = '';
+		$wmgSharedUploadDBname = '';
+		$wmgUploadHostname = '';
+		$wgConf = $this->mockConfig();
+		$wi = (object)[
+			'dbname' => '',
+		];
+
+		require_once __DIR__ . '/../../ManageWikiSettings.php';
+		$this->assertSchema(
+			$wgManageWikiSettings,
+			self::SCHEMA
+		);
+	}
+
+	/** @inheritDoc */
+	public function configProvider(): array {
+		return [
+			'A valid configuration should be passed the validation.' => [
+				[
+					'wgAbuseFilterActions' => [
+						'name' => 'AbuseFilter Actions',
+						'from' => 'abusefilter',
+						'type' => 'list-multi-bool',
+						'overridedefault' => [
+							'block' => true,
+						],
+						'section' => 'anti-spam',
+						'help' => 'Lorem ipsum.',
+					]
+				],
+				self::SCHEMA,
+				true
+			],
+			'An invalid configuration should not be passed the validation.' => [
+				[
+					'wgAbuseFilterActions' => [
+						'foo' => 'bar'
+					]
+				],
+				self::SCHEMA,
+				false
+			],
+		];
+	}
+}

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -144,16 +144,22 @@ class SettingsTest extends ManageWikiTestCase {
 					]
 				],
 				self::SCHEMA,
-				true
+				''
 			],
 			'An invalid configuration should not be passed the validation.' => [
 				[
 					'wgAbuseFilterActions' => [
-						'foo' => 'bar'
+						'type' => 'check',
 					]
 				],
 				self::SCHEMA,
-				false
+				implode( "\n", [
+					'[wgAbuseFilterActions.name] The property name is required',
+					'[wgAbuseFilterActions.from] The property from is required',
+					'[wgAbuseFilterActions.overridedefault] The property overridedefault is required',
+					'[wgAbuseFilterActions.section] The property section is required',
+					'[wgAbuseFilterActions.help] The property help is required',
+				] ),
 			],
 		];
 	}

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -14,6 +14,7 @@ class SettingsTest extends ManageWikiTestCase {
 					'properties' => [
 						'name' => [
 							'type' => 'string',
+							'pattern' => self::REGEX_READABLE,
 							'required' => true,
 						],
 						'from' => [
@@ -60,6 +61,9 @@ class SettingsTest extends ManageWikiTestCase {
 						],
 						'options' => [
 							'type' => 'array',
+							'patternProperties' => [
+								self::REGEX_READABLE => []
+							]
 						],
 						'minint' => [
 							'type' => 'integer',
@@ -76,6 +80,7 @@ class SettingsTest extends ManageWikiTestCase {
 						],
 						'help' => [
 							'type' => 'string',
+							'pattern' => self::REGEX_READABLE,
 							'required' => true,
 						],
 						'requires' => [


### PR DESCRIPTION
This adds two classes:

- **SettingsTest**
  - is a subclass of TestCase,
  - contains a schema for `$wgManageWikiSettings`,
  - and tests:
    - Whether ManageWikiSettings.php file is valid.
    - Whether the given schema works against short configuration examples.
- **ManageWikiTestCase** is an abstract class and is split from SettingsTest for the future implementation of the validation of ManageWikiExtensions.php, etc.

This includes two new dependencies:

- `phpunit/phpunit`
- `justinrainbow/json-schema` which is the package used by WMF for the [maintenance/validateRegistrationFile.php script](https://mediawiki.org/wiki/Special:MyLanguage/Manual:ValidateRegistrationFile.php).

Thank you!