### PR TITLE
Remove unused namespace(s) types

### DIFF
--- a/ManageWikiNamespaces.php
+++ b/ManageWikiNamespaces.php
@@ -30,8 +30,6 @@
  * list-multi: see above, just that multiple can be selected.
  * list-multi-bool: see above, just outputs are $this => $bool.
  * matrix: adds an array of "columns" and "rows". Columns are the top array and rows will be the values.
- * namespace: adds dropdown to select one namespace.
- * namespaces: see above, except multiple namespaces.
  * preferences: adds a drop down selection box for selecting multiple user preferences.
  * skin: adds a drop down selection box for selecting a single enabled skin.
  * skins: adds a drop down selection box for selecting multiple enabled skins.

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -24,8 +24,6 @@
  * list-multi: see above, just that multiple can be selected.
  * list-multi-bool: see above, just outputs are $this => $bool.
  * matrix: adds an array of "columns" and "rows". Columns are the top array and rows will be the values.
- * namespace: adds dropdown to select one namespace.
- * namespaces: see above, except multiple namespaces.
  * preferences: adds a drop down selection box for selecting multiple user preferences.
  * skin: adds a drop down selection box for selecting a single enabled skin.
  * skins: adds a drop down selection box for selecting multiple enabled skins.

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -75,14 +75,6 @@ class SettingsTest extends ManageWikiTestCase {
 									'description' => 'adds an array of "columns" and "rows". Columns are the top array and rows will be the values.',
 								],
 								[
-									'const' => 'namespace',
-									'description' => 'adds dropdown to select one namespace.',
-								],
-								[
-									'const' => 'namespaces',
-									'description' => 'see above, except multiple namespaces.',
-								],
-								[
 									'const' => 'preferences',
 									'description' => 'adds a drop down selection box for selecting multiple user preferences.',
 								],


### PR DESCRIPTION
Namespace configs are set via ManageWikiNamespaces, these types are unused, and will soon be removed from ManageWiki itself.