### PR TITLE
Remove user rights sysadmin did not have

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2483,10 +2483,8 @@ $wgConf->settings += [
 				'globalgrouppermissions' => true,
 			],
 			'sysadmin' => [
-				'userrights' => true,
 				'globalgroupmembership' => true,
 				'globalgrouppermissions' => true,
-				'userrights-interwiki' => true,
 			],
 			'trustandsafety' => [
 				'userrights' => true,


### PR DESCRIPTION
The addition of `userrights` and `userrights-interwiki` was an unauthorized additional access/access elevation request that required the public approval of either one of or both of the Engineering Managers. Reverting per discussion with @Universal-Omega on IRC