### PR TITLE
revert unauthorized changes made without consensus

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3173,12 +3173,6 @@ $wgConf->settings += [
 		'ldapwikiwiki' => 'ldapwikiwiki',
 		'betaheze' => 'testglobal',
 	],
-	'wgOATHExclusiveRights' => [
-		'metawiki' => [
-			'edituserjs',
-			'editsitejs',
-		],
-	],
 	// OAuth
 	'wgMWOAuthCentralWiki' => [
 		'default' => 'metawiki',


### PR DESCRIPTION
This so-called "security change" has very little change to security and only sees to make some interface admins unable to do their job. In addition, there was not consensus for this change which absolutely must have been obtained first