### PR TITLE
remove OpenGraphFallbackImage and ExpandOpenSearchXml

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3230,14 +3230,6 @@ $wgConf->settings += [
 		'default' => false,
 		'gratispaideiawiki' => true,
 	],
-	'wgPageImagesOpenGraphFallbackImage' => [
-		'default' => false,
-		'gratispaideiawiki' => 'https://static.miraheze.org/commonswiki/2/2a/Gratispaideia-logo.svg',
-	],
-	'wgPageImagesLeadSectionOnly' => [
-		'default' => false,
-		'gratispaideiawiki' => true,
-	],
 
 	// Pagelang
 	'wgPageLanguageUseDB' => [


### PR DESCRIPTION
I removed them entirely because gratispaideia is the only one that uses a different value and the defaults are already set on extension.json