### PR TITLE
override page HTML title with the wikibase label, if available, or else the id

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -29,10 +29,10 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'gratisdatawiki':
-		$wgHooks['overridePageMetaTags'][] = 'overridePageMetaTags';
+		$wgHooks['overridePageMetaTags'][] = 'onoverridePageMetaTags';
 		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
 		// The title of wikibase entities will be the label, if available, or else the entity id (e.g. 'Q42').
-		function overridePageMetaTags( OutputPage $outputPage ) {
+		function onoverridePageMetaTags( OutputPage $outputPage ) {
 			$meta = $this->getOutput()->getProperty( 'wikibase-meta-tags' );
 			// This would remove description, social media tags, or any search engine optimization for diffs
 			if ( $this->isDiff() ) {

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -53,7 +53,6 @@ switch ( $wi->dbname ) {
 				
 		function onBeforePageDisplay( OutputPage $out ) {
 			$out->addMeta( 'og:image:width', '1200' );
-			$out->addMeta( 'revisit-after', '1 days' );
 		}
 		
 		break;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -45,6 +45,7 @@ switch ( $wi->dbname ) {
 				return;
 			}
 			$out->addMeta( 'og:image', wfExpandUrl( $thumb->getUrl(), PROTO_CANONICAL ) );
+			$out->addMeta( 'revisit-after', '1 days' );
 		}
 		
 		break;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -29,10 +29,10 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'gratisdatawiki':
-		$wgHooks['overridePageMetaTags'][] = 'onoverridePageMetaTags';
+		$wgHooks['OverridePageMetaTags'][] = 'onOverridePageMetaTags';
 		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
 		// The title of wikibase entities will be the label, if available, or else the entity id (e.g. 'Q42').
-		function onoverridePageMetaTags( OutputPage $outputPage ) {
+		function onOverridePageMetaTags( OutputPage $outputPage ) {
 			$meta = $this->getOutput()->getProperty( 'wikibase-meta-tags' );
 			// This would remove description, social media tags, or any search engine optimization for diffs
 			if ( $this->isDiff() ) {

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -28,6 +28,15 @@ switch ( $wi->dbname ) {
 		}
 
 		break;
+	case 'gratisdatawiki':
+		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
+		
+		function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
+			$meta = $out->getMetaTags();
+			
+			if ( !isset( $meta['og:type'] ) && !isset( $meta['twitter:card'] ) ) {
+		
+		break;
 	case 'ldapwikiwiki':
 		wfLoadExtension( 'LdapAuthentication' );
 

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -30,6 +30,7 @@ switch ( $wi->dbname ) {
 		break;
 	case 'gratisdatawiki':
 		$wgHooks['OutputPageParserOutput'][] = 'onOutputPageParserOutput';
+		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
 		
 		function onOutputPageParserOutput( OutputPage $out, ParserOutput $parserOutput ) {
 			$placeholders = $parserOutput->getExtensionData( 'wikibase-view-chunks' );
@@ -48,11 +49,8 @@ switch ( $wi->dbname ) {
 					$out->addLink( $link );
 				}
 			}
-			
-			return true;
 		}
-		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
-			
+				
 		function onBeforePageDisplay( OutputPage $out ) {
 			$out->addMeta( 'og:image:width', '1200' );
 			$out->addMeta( 'og:image', wfExpandUrl( $thumb->getUrl(), PROTO_CANONICAL ) );

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -35,6 +35,7 @@ switch ( $wi->dbname ) {
 			$meta = $out->getMetaTags();
 			
 			if ( !isset( $meta['og:type'] ) && !isset( $meta['twitter:card'] ) ) {
+				$out->addMeta( 'og:type', 'summary' );
 		
 		break;
 	case 'ldapwikiwiki':

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -40,10 +40,6 @@ switch ( $wi->dbname ) {
 			if ( !isset( $meta['og:title'] ) ) {
 				$out->addMeta( 'og:title', $out->getHTMLTitle() );
 			}
-			$imageFile = self::getPageImage( $out->getContext()->getTitle() );
-			if ( !$imageFile ) {
-				return;
-			}
 			$thumb = $imageFile->transform( [ 'width' => 1200 ] );
 			if ( !$thumb ) {
 				return;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -53,7 +53,6 @@ switch ( $wi->dbname ) {
 				
 		function onBeforePageDisplay( OutputPage $out ) {
 			$out->addMeta( 'og:image:width', '1200' );
-			$out->addMeta( 'og:image', wfExpandUrl( $thumb->getUrl(), PROTO_CANONICAL ) );
 			$out->addMeta( 'revisit-after', '1 days' );
 		}
 		

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -29,7 +29,7 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'gratisdatawiki':
-		$wgHooks['OverridePageMetaTags'][] = 'onOverridePageMetaTags';
+		$wgHooks['overridePageMetaTags'][] = 'onOverridePageMetaTags';
 		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
 		// The title of wikibase entities will be the label, if available, or else the entity id (e.g. 'Q42').
 		function onOverridePageMetaTags( OutputPage $outputPage ) {

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -40,6 +40,15 @@ switch ( $wi->dbname ) {
 			if ( !isset( $meta['og:title'] ) ) {
 				$out->addMeta( 'og:title', $out->getHTMLTitle() );
 			}
+			$imageFile = self::getPageImage( $out->getContext()->getTitle() );
+			if ( !$imageFile ) {
+				return;
+			}
+			$thumb = $imageFile->transform( [ 'width' => 1200 ] );
+			if ( !$thumb ) {
+				return;
+			}
+			$out->addMeta( 'og:image', wfExpandUrl( $thumb->getUrl(), PROTO_CANONICAL ) );
 		}
 		
 		break;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -36,6 +36,11 @@ switch ( $wi->dbname ) {
 			
 			if ( !isset( $meta['og:type'] ) && !isset( $meta['twitter:card'] ) ) {
 				$out->addMeta( 'og:type', 'summary' );
+			}
+			if ( !isset( $meta['og:title'] ) ) {
+				$out->addMeta( 'og:title', $out->getHTMLTitle() );
+			}
+		}
 		
 		break;
 	case 'ldapwikiwiki':

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -34,10 +34,12 @@ switch ( $wi->dbname ) {
 		
 		break;
   case 'gratisdatawiki':
-		$wgHooks['overridePageMetaTags'][] = 'onOverridePageMetaTags';
 		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
-		// The title of wikibase entities will be the label, if available, or else the entity id (e.g. 'Q42').
-		function onOverridePageMetaTags( OutputPage $outputPage ) {
+		
+		function onBeforePageDisplay( OutputPage $outputPage ) {
+			$out->addMeta( 'og:image:width', '1200' );
+			
+			// The title of wikibase entities will be the label, if available, or else the entity id (e.g. 'Q42').
 			$meta = $this->getOutput()->getProperty( 'wikibase-meta-tags' );
 			// This would remove description, social media tags, or any search engine optimization for diffs
 			if ( $this->isDiff() ) {
@@ -59,10 +61,6 @@ switch ( $wi->dbname ) {
 					$outputPage->addMeta( 'og:type', 'summary' );
 				}
 			}
-		}
-				
-		function onBeforePageDisplay( OutputPage $out ) {
-			$out->addMeta( 'og:image:width', '1200' );
 		}
 		
 		break;


### PR DESCRIPTION
This may or may not require an extensive review. Currently while sharing wikibase entities on social platforms, like Discord, Telegram, etc, the item shows the Qxxx instead of the item's label, so this is a possible fix.