### PR TITLE
metawiki: drop long unused metatags

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -59,8 +59,6 @@ switch ( $wi->dbname ) {
 
 		function onBeforePageDisplay( OutputPage $out ) {
 			$out->addMeta( 'description', 'Miraheze is an open source project that offers free MediaWiki hosting, for everyone. Request your free wiki today!' );
-			$out->addMeta( 'revisit-after', '2 days' );
-			$out->addMeta( 'keywords', 'miraheze, free, wiki hosting, mediawiki, mediawiki hosting, open source, hosting' );
 		}
 
 		$wgHooks['SkinBuildSidebar'][] = 'onSkinBuildSidebar';


### PR DESCRIPTION
These have no benefit to SEO and haven't been used to much effect by any major browser in years