### PR TITLE
removing repoSiteId from gratispaideiawiki and benpediawiki

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -240,13 +240,11 @@ if ( $wgDBname === 'gratispaideiawiki' ) {
 	$wgWBClientSettings['echoIcon'] = [
 		'url' => 'https://static.miraheze.org/commonswiki/a/a4/GDechoIcon.svg',
 	];
-	$wgWBClientSettings['repoSiteId'] = 'gratisdatawiki';
 	$wgWBClientSettings['propertyOrderUrl'] = 'https://gratisdata.miraheze.org/wiki/MediaWiki:Wikibase-SortedProperties?action=raw&sp_ver=1';
 }
 
 if ( $wgDBname === 'benpediawiki' ) {
 	$wgWBClientSettings['repoSiteName'] = 'Gratisdata';
-	$wgWBClientSettings['repoSiteId'] = 'gratisdatawiki';
 	$wgWBClientSettings['pageSchemaNamespaces'] = [ 0 ];
 }
 


### PR DESCRIPTION
This is practically not needed, the default for this config is siteGlobalID, although siteGlobalID isn't set but the default for siteGlobalID is $wgDBname, which makes repoSiteId ends up at $wgDBname.