### PR TITLE
Add essential special pages to `*`

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2305,9 +2305,9 @@ $wgConf->settings += [
 				'oathauth-enable' => true,
 				'editmyprivateinfo' => true,
 				'viewmyprivateinfo' => true,
-				'editmyoptions',
-				'editmyprivateinfo',
-				'editmywatchlist',
+				'editmyoptions' => true,
+				'editmyprivateinfo' => true,
+				'editmywatchlist' => true,
 				'writeapi' => true,
 			],
 			'checkuser' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2303,7 +2303,6 @@ $wgConf->settings += [
 				'autocreateaccount' => true,
 				'read' => true,
 				'oathauth-enable' => true,
-				'editmyprivateinfo' => true,
 				'viewmyprivateinfo' => true,
 				'editmyoptions' => true,
 				'editmyprivateinfo' => true,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2305,6 +2305,9 @@ $wgConf->settings += [
 				'oathauth-enable' => true,
 				'editmyprivateinfo' => true,
 				'viewmyprivateinfo' => true,
+				'editmyoptions',
+				'editmyprivateinfo',
+				'editmywatchlist',
 				'writeapi' => true,
 			],
 			'checkuser' => [


### PR DESCRIPTION
Per [SN request](https://meta.miraheze.org/w/index.php?title=Stewards%27_noticeboard&diff=next&oldid=246492&diffmode=source#I_have_a_question). This has created the scenario where these rights where these rights were blacklisted from being removed from `*`, but on wikis that already removed them, they cannot be re-added, by local bureaucrats or Stewards. This was an unfortunate oversight as these _should've_ been made default `*` rights, locked down from being removed in ManageWiki