### PR TITLE
Set spamblacklist to true on all wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -191,14 +191,9 @@ $wgConf->settings += [
 	],
 	'wgLogSpamBlacklistHits' => [
 		'default' => true,
-		'metawiki' => true,
-		'betaheze' => true,
 	],
 	'wgTitleBlacklistLogHits' => [
 		'default' => true,
-		'loginwiki' => true,
-		'metawiki' => true,
-		'betaheze' => true,
 	],
 
 	// ApprovedRevs

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -190,12 +190,12 @@ $wgConf->settings += [
 		],
 	],
 	'wgLogSpamBlacklistHits' => [
-		'default' => false,
+		'default' => true,
 		'metawiki' => true,
 		'betaheze' => true,
 	],
 	'wgTitleBlacklistLogHits' => [
-		'default' => false,
+		'default' => true,
 		'loginwiki' => true,
 		'metawiki' => true,
 		'betaheze' => true,


### PR DESCRIPTION
Set `default` to `true`, as this would be useless to us otherwise. Individual wikis would still be able to control who has access to the spam blacklist log by setting `spamblacklist` to a group other than `user`