### PR TITLE
remove wgJsonConfigInterwikiPrefix "c" for gpcommonswiki....

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1966,7 +1966,6 @@ $wgConf->settings += [
 	'wgJsonConfigInterwikiPrefix' => [
 		'default' => 'commons',
 		'commonswiki' => 'meta',
-		'gpcommonswiki' => 'c',
 	],
 	'wgJsonConfigModels' => [
 		'default' => [


### PR DESCRIPTION
....since "commons" is also set on the wikis Special:Interwiki