### PR TITLE
setting JsonConfig "isLocal" to true for gpcommonswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1951,7 +1951,7 @@ $wgConf->settings += [
 				// page name must end in ".tab", and contain at least one symbol
 				'pattern' => '/.\.tab$/',
 				'license' => 'CC0-1.0',
-				'isLocal' => false,
+				'isLocal' => true,
 			],
 			'Map.JsonConfig' => [
 				'namespace' => 486,
@@ -1959,7 +1959,7 @@ $wgConf->settings += [
 				// page name must end in ".map", and contain at least one symbol
 				'pattern' => '/.\.map$/',
 				'license' => 'CC0-1.0',
-				'isLocal' => false,
+				'isLocal' => true,
 			],
 		],
 	],


### PR DESCRIPTION
Quoting the doc on the extension page "If true, this configuration will not be shared across the cluster, but rather each wiki would have a local config"
and I presume that is why we still don't have the data namespace on gpcommonswiki.