### PR TITLE
T9145: Add protection level for collegecitoyenwiki and knightnwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3674,6 +3674,9 @@ $wgConf->settings += [
 			'pm',
 			'member',
 		],
+		'+collegecitoyenwiki' => [
+			'editextendedsemiprotected',
+		],
 		'+devwiki' => [
 			'editinterface',
 		],
@@ -3704,6 +3707,9 @@ $wgConf->settings += [
 			'bureaucrat',
 			'ceo',
 			'co',
+		],
+		'+knightnwiki' => [
+			'editextendedsemiprotected',
 		],
 		'+lhmnwiki' => [
 			'editqualityarticles',
@@ -3773,6 +3779,9 @@ $wgConf->settings += [
 			'edittemplateprotected',
 			'editfounderprotected',
 		],
+		'collegecitoyenwiki' => [
+			'editextendedsemiprotected',
+		],
 		'famedatawiki' => [
 			'editextendedconfirmedprotected',
 			'edittemplateprotected',
@@ -3792,6 +3801,9 @@ $wgConf->settings += [
 			'editextendedconfirmedprotected',
 			'editbureaucratprotected',
 			'editleaderprotected',
+		],
+		'knightnwiki' => [
+			'editextendedsemiprotected',
 		],
 		'lhmnwiki' => [
 			'editqualityarticles',


### PR DESCRIPTION
Added `editextendedsemiprotected` protection level for `collegecitoyenwiki` and `knightnwiki`. Requested on T9145.