### PR TITLE
Guarantee that server is always a string

### DIFF
--- a/initialise/MirahezeFunctions.php
+++ b/initialise/MirahezeFunctions.php
@@ -205,7 +205,10 @@ class MirahezeFunctions {
 	}
 
 	public static function getServer() {
-		return self::getServers( self::getCurrentDatabase() );
+		$server = self::getServers( self::getCurrentDatabase() );
+
+		return is_string( $server ) ? $server :
+			'https://' . self::SUFFIXES[ array_key_first( self::SUFFIXES ) ];
 	}
 
 	public function setServers() {

--- a/initialise/MirahezeFunctions.php
+++ b/initialise/MirahezeFunctions.php
@@ -49,7 +49,7 @@ class MirahezeFunctions {
 		$this->setSiteNames();
 	}
 
-	public static function getLocalDatabases() {
+	public static function getLocalDatabases(): array {
 		static $list = null;
 		static $databases = null;
 
@@ -118,7 +118,7 @@ class MirahezeFunctions {
 		$wgHooks['CreateWikiJsonGenerateDatabaseList'][] = 'MirahezeFunctions::onGenerateDatabaseLists';
 	}
 
-	public static function getRealm() {
+	public static function getRealm(): string {
 		static $realm = null;
 
 		$realm ??= isset( array_flip( self::readDbListFile( 'beta' ) )[ self::getCurrentDatabase() ] ) ?
@@ -137,10 +137,12 @@ class MirahezeFunctions {
 
 		$servers['default'] = 'https://' . self::SUFFIXES[ array_key_first( self::SUFFIXES ) ];
 
-		if ( $database ) {
-			foreach ( array_flip( self::SUFFIXES ) as $suffix ) {
-				if ( substr( $database, -strlen( $suffix ) ) === $suffix ) {
-					return $databases['u'] ?? 'https://' . substr( $database, 0, -strlen( $suffix ) ) . '.' . self::SUFFIXES[$suffix];
+		if ( $database !== null ) {
+			if ( is_string( $database ) && $database !== 'default' ) {
+				foreach ( array_flip( self::SUFFIXES ) as $suffix ) {
+					if ( substr( $database, -strlen( $suffix ) ) === $suffix ) {
+						return $databases['u'] ?? 'https://' . substr( $database, 0, -strlen( $suffix ) ) . '.' . self::SUFFIXES[$suffix];
+					}
 				}
 			}
 
@@ -193,7 +195,7 @@ class MirahezeFunctions {
 		$wgConf->extractGlobal( 'wgDBname', $this->dbname );
 	}
 
-	public static function getDatabaseClusters() {
+	public static function getDatabaseClusters(): array {
 		$allDatabases = self::readDbListFile( self::LISTS[self::getRealm()], false );
 		$deletedDatabases = self::readDbListFile( 'deleted-' . self::LISTS[self::getRealm()], false );
 
@@ -204,11 +206,8 @@ class MirahezeFunctions {
 		return array_combine( array_keys( $databases ), $clusters );
 	}
 
-	public static function getServer() {
-		$server = self::getServers( self::getCurrentDatabase() );
-
-		return is_string( $server ) ? $server :
-			'https://' . self::SUFFIXES[ array_key_first( self::SUFFIXES ) ];
+	public static function getServer(): string {
+		return self::getServers( self::getCurrentDatabase() ?: 'default' );
 	}
 
 	public function setServers() {


### PR DESCRIPTION
Additional forcing of other types where necessary.

I noticed this in Nginx error logs:
```st
[error] 579906#579906: *3888176 FastCGI sent in stderr: "PHP message: PHP Warning:  preg_match() expects parameter 2 to be string, array given in /srv/mediawiki/config/GlobalCache.php on line 32"
```
this means that if a user were to visit a second-level non-existent subdomain like www.example.example.miraheze.org, since it is still miraheze.org it tries to find a server there, when it can't, it returns all of them for the server, since the current database returns `null`.