### PR TITLE
fixing localClientDatabases config for gratisdatawiki

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -232,9 +232,9 @@ if ( $wgDBname === 'gratisdatawiki' ) {
 		'http://gratisdata.miraheze.org/entity/Q2123' => 'pluto',
 	];
 	$wgWBRepoSettings['localClientDatabases'] = [
-		'gratispaideiawiki',
-		'gpcommonswiki',
-		'benpediawiki'
+		'gratispaideia' => 'gratispaideiawiki',
+		'gpcommons' => 'gpcommonswiki',
+		'benpedia' => 'benpediawiki',
 	];
 	$wgWBRepoSettings['updateRepoTags'] = [
 		'client-automatic-update'


### PR DESCRIPTION
this is how it should look.
gratispaideia (standing as the client's interwiki prefix on gratisdata's interwiki table); and
gratispaideiawiki (standing as the client dbname).