### PR TITLE
PageImages: make MediaWiki:Pageimages-denylist work everywhere

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3299,7 +3299,6 @@ $wgConf->settings += [
 		],
 	],
 	'wgPageImagesDenylist' => [
-		'default' => [],
 		'wmgUsePageImages' => [
 			'type' => 'db',
 			'page' => 'MediaWiki:Pageimages-denylist',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3300,7 +3300,7 @@ $wgConf->settings += [
 	],
 	'wgPageImagesDenylist' => [
 		'default' => [],
-		'gratispaideiawiki' => [
+		'wgUsePageImages' => [
 			'type' => 'db',
 			'page' => 'MediaWiki:Pageimages-denylist',
 			'db' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3300,7 +3300,7 @@ $wgConf->settings += [
 	],
 	'wgPageImagesDenylist' => [
 		'default' => [],
-		'wgUsePageImages' => [
+		'wmgUsePageImages' => [
 			'type' => 'db',
 			'page' => 'MediaWiki:Pageimages-denylist',
 			'db' => false,


### PR DESCRIPTION
Requested on TestWiki, don't see why this can't be available for everyone.