### PR TITLE
Revert "Revert "Set meta tags on entity pages gratisdatawiki""

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -44,6 +44,25 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'gratisdatawiki':
+		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';
+		
+		function onBeforePageDisplay( OutputPage $outputPage ) {
+			$outputPage->addMeta( 'og:image:width', '1200' );
+			
+			$meta = $outputPage->getProperty( 'wikibase-meta-tags' );
+			if ( isset( $meta['title'] ) ) {
+				$outputPage->addMeta( 'og:title', $meta['title'] );
+			}
+			
+			if ( isset( $meta['description'] ) ) {
+				$outputPage->addMeta( 'description', $meta['description'] );
+				$outputPage->addMeta( 'og:description', $meta['description'] );
+				
+				if ( isset( $meta['title'] ) ) {
+					$outputPage->addMeta( 'og:type', 'summary' );
+				}
+			}
+		}	
 		$wgJsonConfigs['Tabular.JsonConfig']['remote'] = [
 			'url' => 'https://gpcommons.miraheze.org/w/api.php'
 		];


### PR DESCRIPTION
Reverts miraheze/mw-config#4692

Please merge this back, I think there's a conflict with the way WikiSEO works with wikibase, I had to disable it, as we actually don't need it at all for gratisdata.

So this should be set back.