### PR TITLE
Remove `$wgCitizenEnableDrawerSubSearch` from ManageWikiSettings

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -579,9 +579,6 @@ $wgConf->settings += [
 	'wgCitizenShowPageTools' => [
 		'default' => true,
 	],
-	'wgCitizenEnableDrawerSubSearch' => [
-		'default' => false,
-	],
 	'wgCitizenPortalAttach' => [
 		'default' => 'first',
 	],

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3228,15 +3228,6 @@ $wgManageWikiSettings = [
 		'help' => 'The condition of page tools visibility.',
 		'requires' => [],
 	],
-	'wgCitizenEnableDrawerSubSearch' => [
-		'name' => 'Citizen Enable Drawer Sub Search',
-		'from' => 'citizen',
-		'type' => 'check',
-		'overridedefault' => false,
-		'section' => 'styling',
-		'help' => 'Enables the drawer search box for menu entries.',
-		'requires' => [],
-	],
 	'wgCitizenPortalAttach' => [
 		'name' => 'Citizen Portal Attach',
 		'from' => 'citizen',


### PR DESCRIPTION
It is deprecated in the Citizen skin in `5ccfbcfdeb39b8b3543457fda5d913c02276ddab`
Currently Miraheze is on an older version, please merge when the skin is updated next time.