### PR TITLE
Add search-related Citizen config to ManageWikiSettings

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -588,6 +588,18 @@ $wgConf->settings += [
 	'wgCitizenThemeColor' => [
 		'default' => '#131a21',
 	],
+	'wgCitizenEnableSearch' => [
+		'default' => true,
+	],
+	'wgCitizenSearchGateway' => [
+		'default' => 'mwActionApi',
+	],
+	'wgCitizenSearchDescriptionSource' => [
+		'default' => 'textextracts',
+	],
+	'wgCitizenMaxSearchResults' => [
+		'default' => 6,
+	],
 
 	// Comments
 	'wgCommentsDefaultAvatar' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3296,7 +3296,7 @@ $wgManageWikiSettings = [
 		'help' => 'Source of description text on search suggestions',
 		'requires' => [
 			'settings' => [
-				'setting' => 'wgCitizenSearchDescriptionSource',
+				'setting' => 'wgCitizenSearchGateway',
 				'value' => 'mwActionApi',
 			],
 		],

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3255,6 +3255,68 @@ $wgManageWikiSettings = [
 		'help' => 'The color defined in the <code>theme-color</code> meta tag.',
 		'requires' => [],
 	],
+	'wgCitizenEnableSearch' => [
+		'name' => 'Citizen Enable Search',
+		'from' => 'citizen',
+		'type' => 'check',
+		'overridedefault' => true,
+		'section' => 'styling',
+		'help' => 'Enable or disable rich search suggestions',
+		'requires' => [],
+	],
+	'wgCitizenSearchGateway' => [
+		'name' => 'Citizen Search Gateway',
+		'from' => 'citizen',
+		'type' => 'list',
+		'options' => [
+			'Action API' => 'mwActionApi',
+			'REST API' => 'mwRestApi',
+		],
+		'overridedefault' => 'mwActionApi',
+		'section' => 'styling',
+		'help' => 'Which gateway to use for fetching search suggestion',
+		'requires' => [
+			'settings' => [
+				'setting' => 'wgCitizenEnableSearch',
+				'value' => true,
+			],
+		],
+	],
+	'wgCitizenSearchDescriptionSource' => [
+		'name' => 'Citizen Search Description Source',
+		'from' => 'citizen',
+		'type' => 'list',
+		'options' => [
+			'TextExtracts' => 'textextracts',
+			'ShortDescription/Wikidata' => 'wikidata',
+			'Description2/WikiSEO' => 'pagedescription',
+		],
+		'overridedefault' => 'textextracts',
+		'section' => 'styling',
+		'help' => 'Source of description text on search suggestions',
+		'requires' => [
+			'settings' => [
+				'setting' => 'wgCitizenSearchDescriptionSource',
+				'value' => 'mwActionApi',
+			],
+		],
+	],
+	'wgCitizenMaxSearchResults' => [
+		'name' => 'Citizen Max Search Results',
+		'from' => 'citizen',
+		'type' => 'integer',
+		'minint' => 1,
+		'maxint' => 15,
+		'overridedefault' => 6,
+		'section' => 'styling',
+		'help' => 'Max number of search suggestions',
+		'requires' => [
+			'settings' => [
+				'setting' => 'wgCitizenEnableSearch',
+				'value' => true,
+			],
+		],
+	],
 	'wgRelatedArticlesFooterAllowedSkins' => [
 		'name' => 'RelatedArticles Footer Allowed Skins',
 		'from' => 'relatedarticles',


### PR DESCRIPTION
* `$wgCitizenEnableSearch` - Enable or disable Citizen search module. Useful for unbreaking and also wikis with custom search suggestions (e.g. Wikidata)
* `$wgCitizenSearchGateway` - Default API to use for search, some wikis might prefer REST API
* `$wgCitizenSearchDescriptionSource` - MH supports ShortDescription, Wikidata, Description2, and WikiSEO, so it is better to let the user pick where they get the search suggestion description from.
* `$wgCitizenMaxSearchResults` - Max search result in suggestions

Note that `$wgCitizenSearchDescriptionSource` has both prerequisites:
* `$wgCitizenEnableSearch` has to be `true`
* `$wgCitizenSearchGateway` has to be `mwActionApi`
But I am not sure whether `requires` support multiple items so I have only put `$wgCitizenSearchDescriptionSource`.