### PR TITLE
Only check if cache file exists in loadExtensions

### DIFF
--- a/initialise/MirahezeFunctions.php
+++ b/initialise/MirahezeFunctions.php
@@ -612,9 +612,7 @@ class MirahezeFunctions {
 	}
 
 	public function loadExtensions() {
-		$this->cacheArray ??= self::getCacheArray();
-
-		if ( !$this->cacheArray ) {
+		if ( !file_exists( self::CACHE_DIRECTORY . '/' . self::getCurrentDatabase() . '.json' ) ) {
 			global $wgConf;
 			if ( self::getRealm() !== 'default' ) {
 				$wgConf->siteParamsCallback = static function () {

--- a/initialise/MirahezeFunctions.php
+++ b/initialise/MirahezeFunctions.php
@@ -612,7 +612,9 @@ class MirahezeFunctions {
 	}
 
 	public function loadExtensions() {
-		if ( !file_exists( self::CACHE_DIRECTORY . '/' . self::getCurrentDatabase() . '.json' ) ) {
+		global $wgDBname;
+
+		if ( !file_exists( self::CACHE_DIRECTORY . '/' . $wgDBname . '.json' ) ) {
 			global $wgConf;
 			if ( self::getRealm() !== 'default' ) {
 				$wgConf->siteParamsCallback = static function () {


### PR DESCRIPTION
Prevents ever loading/reading ManageWiki cache file if config cache is already generated.