### PR TITLE
use properties for setting globals

### DIFF
--- a/initialise/MirahezeFunctions.php
+++ b/initialise/MirahezeFunctions.php
@@ -262,14 +262,14 @@ class MirahezeFunctions {
 		global $wgConf, $wgServer;
 
 		$wgConf->settings['wgServer'] = self::getServers( null, true );
-		$wgServer = self::getServer();
+		$wgServer = $this->server;
 	}
 
 	public function setSiteNames() {
 		global $wgConf, $wgSitename;
 
 		$wgConf->settings['wgSitename'] = self::getSiteNames();
-		$wgSitename = self::getSiteName();
+		$wgSitename = $this->sitename;
 	}
 
 	public static function getSiteNames() {


### PR DESCRIPTION
Prevents calling the functions more times, providing minor performance improvement.