### PR TITLE
Remove the `$wgCosmosUseWVUISearch` config

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -687,9 +687,6 @@ $wgConf->settings += [
 	'wgCosmosUseSocialProfileAvatar' => [
 		'default' => true,
 	],
-	'wgCosmosUseWVUISearch' => [
-		'default' => true,
-	],
 	'wgCosmosWikiHeaderBackgroundColor' => [
 		'default' => '#c0c0c0',
 	],

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -2832,15 +2832,6 @@ $wgManageWikiSettings = [
 		'help' => 'Set the opacity level of the content area and custom sidebar for the Cosmos skin in precentage.',
 		'requires' => [],
 	],
-	'wgCosmosUseWVUISearch' => [
-		'name' => 'Cosmos Use WVUI Search',
-		'from' => 'cosmos',
-		'type' => 'check',
-		'overridedefault' => true,
-		'section' => 'styling',
-		'help' => 'Whether to enable the WVUI search of Cosmos. If enabled, search suggestions may include descriptions and thumbnails.',
-		'requires' => [],
-	],
 	'wgCosmosSearchUseActionAPI' => [
 		'name' => 'Cosmos Search Use Action API',
 		'from' => 'cosmos',


### PR DESCRIPTION
Removed from Cosmos in https://gerrit.wikimedia.org/r/c/mediawiki/skins/Cosmos/+/810127

`mwscript extensions/ManageWiki/populateWikiSettings.php skin --skin=cosmos --wgsetting=wgCosmosUseWVUISearch --sourcelist=false --remove` needs to be ran.