### PR TITLE
Add AbuseFilter rights to CheckUser group

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2263,6 +2263,8 @@ $wgConf->settings += [
 			'checkuser' => [
 				'checkuser' => true,
 				'checkuser-log' => true,
+				'abusefilter-privatedetails' => true,
+				'abusefilter-privatedetails-log' => true,
 			],
 			'interwiki-admin' => [
 				'interwiki' => true


### PR DESCRIPTION
Following a discussion with 2 other Stewards, we have decided that it would be beneficial to add the `abusefilter-privatedetails` and `abusefilter-privatedetails-log` to the `checkuser` group as this would aid in abuse investigations when checking thwarted actions in the AbuseLog which are not in CheckUser. Wikimedia also has these two rights assigned to their `checkuser` group to aid in abuse investigations.