### PR TITLE
Rename `$wgTranslateBlacklist`

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4233,7 +4233,7 @@ $wgConf->settings += [
 	],
 
 	// Translate
-	'wgTranslateBlacklist' => [
+	'wgTranslateDisabledTargetLanguages' => [
 		'default' => [],
 		'metawiki' => [
 			'*' => [


### PR DESCRIPTION
The legacy config was removed long-ago, so has done nothing since then.

Per https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Translate/+/710993.