### PR TITLE
Prevent autocreation on internal wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -388,9 +388,12 @@ $wgConf->settings += [
 	],
 	'wgCentralAuthCreateOnView' => [
 		'default' => true,
+		'cvtwiki' => false,
 		'cwarswiki' => false,
 		'minecraftjapanwiki' => false,
 		'nenawikiwiki' => false,
+		'staffwiki' => false,
+		'stewardswiki' => false
 	],
 	'wgCentralAuthDatabase' => [
 		'default' => 'mhglobal',


### PR DESCRIPTION
Autocreation is not needed on internal wikis and having accounts not be created automatically would provide more clarity for users that X wiki is not meant for help, as people have been confused before on the purpose of some of these wikis if they can't access them