### PR TITLE
Make CodeMirror default for isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3494,6 +3494,7 @@ $wgConf->settings += [
 		],
 		'+isvwiki' => [
 			'flow-topiclist-sortby' => 'newest',
+			'usecodemirror' => 1,
 		],
 		'+kirbywiki' => [
 			'thumbsize' => 3,


### PR DESCRIPTION
(Maybe this should be an option in ManageWiki.)