### PR TITLE
explicitly configure $wgMessageCacheType

### DIFF
--- a/GlobalCache.php
+++ b/GlobalCache.php
@@ -66,6 +66,7 @@ $wgSessionCacheType = 'memcached-mem-2';
 $redisServerIP = '[2a10:6740::6:306]:6379';
 
 $wgMainCacheType = 'memcached-mem-2';
+$wgMessageCacheType = 'memcached-mem-2';
 $wgParserCacheType = 'mysql-multiwrite';
 
 // 10 days


### PR DESCRIPTION
this value appears to be setting itself to `CACHE_ANYTHING`, instead of inheriting $wgMainCacheType. This may then be attempting to use the default memcached server settings, causing most(?) mw requests to generate a memcached error.