### PR TITLE
Require 2FA for certain groups/rights

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3204,11 +3204,17 @@ $wgConf->settings += [
 	],
 	'wgOATHExclusiveRights' => [
 		'default' => [
+			'abusefilter-privatedetails',
+			'abusefilter-privatedetails-log',
 			'centralauth-lock',
+			'centralauth-rename',
 			'centralauth-suppress',
 			'checkuser',
+			'checkuser-log',
+			'globalblock',
 			'globalgrouppermissions',
 			'globalgroupmembership',
+			'suppressionlog',
 			'suppressrevision',
 			'userrights',
 			'userrights-interwiki',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3213,7 +3213,7 @@ $wgConf->settings += [
 			'userrights',
 			'userrights-interwiki',
 		],
-		'metawiki' => [
+		'+metawiki' => [
 			'edituserjs',
 			'editsitejs',
 		],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3224,7 +3224,7 @@ $wgConf->settings += [
 			'oversight',
 			'steward',
 		],
-		'metawiki' => [
+		'+metawiki' => [
 			'globalsysop',
 		],
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3203,6 +3203,16 @@ $wgConf->settings += [
 		'betaheze' => 'testglobal',
 	],
 	'wgOATHExclusiveRights' => [
+		'default' => [
+			'centralauth-lock',
+			'centralauth-suppress',
+			'checkuser',
+			'globalgrouppermissions',
+			'globalgroupmembership',
+			'suppressrevision',
+			'userrights',
+			'userrights-interwiki',
+		],
 		'metawiki' => [
 			'edituserjs',
 			'editsitejs',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3208,6 +3208,16 @@ $wgConf->settings += [
 			'editsitejs',
 		],
 	],
+	'wgOATHRequiredForGroups' => [
+		'default' => [
+			'checkuser',
+			'oversight',
+			'steward',
+		],
+		'metawiki' => [
+			'globalsysop',
+		],
+	],
 	// OAuth
 	'wgMWOAuthCentralWiki' => [
 		'default' => 'metawiki',


### PR DESCRIPTION
Adds 2FA requirements to Steward, GS, CU/OS groups (per RfC) and restricts some very sensitive rights from being used without 2FA regardless of group membership