### PR TITLE
Add upload path for ImportDump on metawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1779,7 +1779,7 @@ $wgConf->settings += [
 		],
 	],
 	'wgImportDumpScriptCommand' => [
-		'default' => 'screen -d -m bash -c "mwscript importDump.php {wiki} -y --no-updates --username-prefix={username-prefix} {file}; mwscript rebuildall.php {wiki} -y; mwscript initSiteStats.php {wiki} --active --update -y"',
+		'default' => 'screen -d -m bash -c "mwscript importDump.php {wiki} -y --no-updates --username-prefix={username-prefix} /mnt/mediawiki-static/metawiki/{file}; mwscript rebuildall.php {wiki} -y; mwscript initSiteStats.php {wiki} --active --update -y"',
 		'betawiki' => 'screen -d -m bash -c "swift download miraheze-mw betawiki/{file} -o /home/$USER/{file}; mwscript importDump.php {wiki} -y --no-updates --username-prefix={username-prefix} /home/$USER/{file}; mwscript rebuildall.php {wiki} -y; mwscript initSiteStats.php {wiki} --active --update -y; rm /home/$USER/{file}"',
 	],
 	'wgImportDumpUsersNotifiedOnAllRequests' => [


### PR DESCRIPTION
To-do once ImportDump is updated. With miraheze/ImportDump#28 it no longer uses the UploadPath, so this is now necessary to give the full file path.