### PR TITLE
Enable CodeEditor and CodeMirror extensions by default

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2258,6 +2258,8 @@ $wgConf->settings += [
 			'categorytree',
 			'cite',
 			'citethispage',
+			'codeeditor',
+			'codemirror',
 			'darkmode',
 			'globaluserpage',
 			'minervaneue',


### PR DESCRIPTION
Per [community proposal](https://meta.miraheze.org/wiki/Special:PermaLink/276371#Request_for_Feedback:_making_syntax_highlighting_enabled_by_default).