### PR TITLE
Add rights to ManageWiki blacklist

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2664,6 +2664,11 @@ $wgConf->settings += [
 				'viewsuppressed',
 				'writeapi',
 			],
+			'user' => [
+				'autoconfirmed',
+				'noratelimit',
+				'skipcaptcha',
+			],
 			'*' => [
 				'read',
 				'skipcaptcha',
@@ -2684,6 +2689,8 @@ $wgConf->settings += [
 				'viewmyprivateinfo',
 				'viewmywatchlist',
 				'managewiki',
+				'noratelimit',
+				'autoconfirmed',
 			],
 		],
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2669,10 +2669,8 @@ $wgConf->settings += [
 				'noratelimit',
 				'skipcaptcha',
 				'managewiki',
-				'generate-dump',
 				'globalblock-whitelist',
 				'ipblock-exempt',
-				'managewiki',
 			],
 			'*' => [
 				'read',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2668,6 +2668,11 @@ $wgConf->settings += [
 				'autoconfirmed',
 				'noratelimit',
 				'skipcaptcha',
+				'managewiki',
+				'generate-dump',
+				'globalblock-whitelist',
+				'ipblock-exempt',
+				'managewiki',
 			],
 			'*' => [
 				'read',


### PR DESCRIPTION
Assigning some of these rights to the `*` and `user` groups bypasses our AbuseFilters and is dangerous overall so we should blacklist these.