### PR TITLE
Add Citizen Enable CJK fonts config

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -560,6 +560,9 @@ $wgConf->settings += [
 	'wgCitizenMaxSearchResults' => [
 		'default' => 6,
 	],
+	'wgCitizenEnableCJKFonts' => [
+		'default' => false,
+	],
 
 	// Comments
 	'wgCommentsDefaultAvatar' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3371,6 +3371,15 @@ $wgManageWikiSettings = [
 			],
 		],
 	],
+	'wgCitizenEnableCJKFonts' => [
+		'name' => 'Citizen Enable CJK fonts',
+		'from' => 'citizen',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'styling',
+		'help' => 'Enable included Noto Sans CJK for wikis that serves CJK languages',
+		'requires' => [],
+	],
 	'wgRelatedArticlesFooterAllowedSkins' => [
 		'name' => 'RelatedArticles Footer Allowed Skins',
 		'from' => 'relatedarticles',


### PR DESCRIPTION
Citizen added Noto Sans CJK fonts support recently in [9b9b361](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/b89873d99cf92beca64bf4c0c4ba2c0f9161f8a2).
This PR will add the config to ManageWiki.