### PR TITLE
Call thumb_handler for thumbs on private wikis

### DIFF
--- a/FileBackend.php
+++ b/FileBackend.php
@@ -54,7 +54,7 @@ if ( $wmgEnableSwift ) {
 		'deletedHashLevels' => 3,
 		'abbrvThreshold' => 160,
 		'isPrivate' => $wmgPrivateUploads,
-		'zones' => $wmgPrivateUploads
+		'zones' => ( $cwPrivate || $wmgPrivateUploads )
 			? [
 				'thumb' => [ 'url' => "$wgScriptPath/thumb_handler.php" ] ]
 			: [],

--- a/FileBackend.php
+++ b/FileBackend.php
@@ -54,7 +54,7 @@ if ( $wmgEnableSwift ) {
 		'deletedHashLevels' => 3,
 		'abbrvThreshold' => 160,
 		'isPrivate' => $wmgPrivateUploads,
-		'zones' => ( $cwPrivate || $wmgPrivateUploads )
+		'zones' => $cwPrivate
 			? [
 				'thumb' => [ 'url' => "$wgScriptPath/thumb_handler.php" ] ]
 			: [],


### PR DESCRIPTION
Not just for those that enable wmgPrivateUploads as we don't pass the cookies on thus when a thumb swift side 404's we call out to thumb_handler but the cookies aren't passed. Thus you get a 404 error.