### PR TITLE
Add `$wgWhitelistReadRegexp`

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3024,6 +3024,9 @@ $wgConf->settings += [
 	'wgWhitelistRead' => [
 		'default' => [],
 	],
+	'wgWhitelistReadRegexp' => [
+		'default' => [],
+	],
 	'wgDisabledVariants' => [
 		'default' => [],
 		'hkrailwiki' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1931,6 +1931,21 @@ $wgManageWikiSettings = [
 			],
 		],
 	],
+	'wgWhitelistReadRegexp' => [
+		'name' => 'Whitelist Read Regular Expressions',
+		'from' => 'mediawiki',
+		'global' => true,
+		'type' => 'texts',
+		'exists' => false,
+		'overridedefault' => [],
+		'section' => 'permissions',
+		'help' => 'Pages that are matched by these regular expressions may be viewed by anyone.',
+		'requires' => [
+			'visibility' => [
+				'state' => 'private',
+			],
+		],
+	],
 
 	// Preferences
 	'wgHiddenPrefs' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1936,7 +1936,6 @@ $wgManageWikiSettings = [
 		'from' => 'mediawiki',
 		'global' => true,
 		'type' => 'texts',
-		'exists' => false,
 		'overridedefault' => [],
 		'section' => 'permissions',
 		'help' => 'Pages that are matched by these regular expressions may be viewed by anyone.',


### PR DESCRIPTION
This setting is useful for private wikis which would like to make a large proportion of pages public (e.g. an entire namespace).

See https://www.mediawiki.org/wiki/Manual:$wgWhitelistReadRegexp