### PR TITLE
Remove c2 from wgCreateWikiDatabaseClusters

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -855,7 +855,6 @@ $wgConf->settings += [
 	],
 	'wgCreateWikiDatabaseClusters' => [
 		'default' => [
-			'c2',
 			'c4',
 			'c5',
 			'c6',
@@ -868,6 +867,7 @@ $wgConf->settings += [
 	'wgCreateWikiDatabaseClustersInactive' => [
 		'default' => [
 			'c1',
+			'c2',
 			'c3',
 		]
 	],


### PR DESCRIPTION
Add it to wgCreateWikiDatabaseClustersInactive in preparation for the migration tomorrow.