### PR TITLE
Add the DataDump rights to a new grant

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1616,7 +1616,6 @@ $wgConf->settings += [
 			],
 			'usedatadumpapi' => [
 				'view-dump' => true,
-				'view-image-dump' => true,
 				'generate-dump' => true,
 				'delete-dump' => true,
 			],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1614,6 +1614,12 @@ $wgConf->settings += [
 			'basic' => [
 				'user' => true,
 			],
+			'usedatadumpapi' => [
+				'view-dump' => true,
+				'view-image-dump' => true,
+				'generate-dump' => true,
+				'delete-dump' => true,
+			],
 		],
 		'+althistorywiki' => [
 			'editprotected' => [


### PR DESCRIPTION
This pull request adds a new grant, (usedatadumpapi). This grant contains all the DataDump extension rights, allowing usage of the DataDump API via OAuth and bot passwords.