### PR TITLE
T10440: Add some Pivot settings to ManageWiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -323,4 +323,8 @@ switch ( $wi->dbname ) {
 		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
 
 		break;
+	case 'wanderingstarswiki':
+		$wgPivotFeatures['showActionsForAnon'] = false;
+
+		break;
 }

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -323,8 +323,4 @@ switch ( $wi->dbname ) {
 		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
 
 		break;
-	case 'wanderingstarswiki':
-		$wgPivotFeatures['showActionsForAnon'] = false;
-
-		break;
 }

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3585,7 +3585,7 @@ $wgManageWikiSettings = [
 			'FixedNavbar' => 'fixedNavBar',
 			'UsePivotTabs' => 'usePivotTabs',
 			'ShowHelpUnderTools' => 'showHelpUnderTools',
-			'ShowRecentChangesUnderTools' => 'showRecentChangesUnderTools'
+			'ShowRecentChangesUnderTools' => 'showRecentChangesUnderTools',
 			'NavbarIcon' => 'navbarIcon',
 			'PreloadFontAwesome' => 'preloadFontAwesome',
 		],

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3565,7 +3565,7 @@ $wgManageWikiSettings = [
 		'section' => 'styling',
 		'help' => 'Whether or not to show the normal MediaWiki external link icon when using the Chameleon skin.',
 		'requires' => [],
-	],*/
+	],
 	'wgPivotFeatures' => [
 		'name' => 'Pivot features',
 		'from' => 'pivot',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3583,6 +3583,7 @@ $wgManageWikiSettings = [
 		'overridedefault' => false,
 		'section' => 'styling',
 		'help' => 'Enable and disable some features of the Pivot skin',
+		'requires' => [],
 	],
 
 	// Wikibase

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3565,6 +3565,23 @@ $wgManageWikiSettings = [
 		'section' => 'styling',
 		'help' => 'Whether or not to show the normal MediaWiki external link icon when using the Chameleon skin.',
 		'requires' => [],
+	],*/
+	'wgPivotFeatures' => [
+		'name' => 'Pivot features',
+		'from' => 'pivot',
+		'global' => true,
+		'type' => 'list-multi-bool',
+		'allopts' => [
+			'showActionsForAnon',
+			'fixedNavBar',
+			'usePivotTabs',
+			'showHelpUnderTools',
+			'showRecentChangesUnderTools',
+			'navbarIcon',
+		],
+		'overridedefault' => false,
+		'section' => 'styling',
+		'help' => 'Enable and disable some features of the Pivot skin',
 	],
 
 	// Wikibase

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3578,6 +3578,7 @@ $wgManageWikiSettings = [
 			'showHelpUnderTools',
 			'showRecentChangesUnderTools',
 			'navbarIcon',
+			'preloadFontAwesome',
 		],
 		'overridedefault' => false,
 		'section' => 'styling',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3580,6 +3580,15 @@ $wgManageWikiSettings = [
 			'navbarIcon',
 			'preloadFontAwesome',
 		],
+		'options' => [
+			'ShowActionsForAnon' => 'showActionsForAnon',
+			'FixedNavbar' => 'fixedNavBar',
+			'UsePivotTabs' => 'usePivotTabs',
+			'ShowHelpUnderTools' => 'showHelpUnderTools',
+			'ShowRecentChangesUnderTools' => 'showRecentChangesUnderTools'
+			'NavbarIcon' => 'navbarIcon',
+			'PreloadFontAwesome' => 'preloadFontAwesome',
+		],
 		'overridedefault' => false,
 		'section' => 'styling',
 		'help' => 'Enable and disable some features of the Pivot skin',


### PR DESCRIPTION
https://phabricator.miraheze.org/T10440

The Pivot skin has an uncommon approach to settings: it doesn't register any configuration variables in skin.json, instead, it accesses an unregistered $wgPivotFeatures global array, and compares it with an internal variable to see if there are any new settings (https://github.com/wikimedia/mediawiki-skins-Pivot/blob/994a682983f867964e0486eb65a79aa2c410bab9/Pivot.skin.php#L13).

The idea here is to make them available through a ManageWiki "list-multi-bool" setting. If not possible due to the way the extension handles configuration, then just add the settings requested there to that wiki's section on LocalWiki.php.