### PR TITLE
T10323: Fix errors with previous commits

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -259,8 +259,8 @@ switch ( $wi->dbname ) {
 			$generalRow->addItem( ALItem::newFromSpecialPage( 'ArticlesHome' ) );
 			$generalRow->addItem( ALItem::newFromSpecialPage( 'EditWatchlist' ) );
 			$generalRow->addItem( ALItem::newFromSpecialPage( 'GlobalPreferences' ) );
-			$generalRow->addItem( ALItem::newFromSpecialPage( 'UploadFile' ) );
-			$generalRow->addItem( ALItem::newFromEditLink( 'Portal', 'Draft portal' ) );
+			$generalRow->addItem( ALItem::newFromSpecialPage( 'Upload' ) );
+			$generalRow->addItem( ALItem::newFromEditLink( 'Draft:Portal', 'Draft portal' ) );
 			$generalRow->addItem( ALItem::newFromEditLink( 'Common.js', 'Edit JS file' ) );
 
 			$users = $adminLinksTree->getSection( wfMessage( 'adminlinks_users' )->text() );


### PR DESCRIPTION
- Special:UploadFile doesn't exist, change to Special:Upload
- Explicitly set namespace for the link to Draft:Portal. I'm not sure if AdminLinks honors namespaces