### PR TITLE
T10446: Set wgAllowImageTag for dgck81lnnwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5544,6 +5544,11 @@ $wgConf->settings += [
 		'default' => '1.34',
 		'betaheze' => false,
 	],
+	// Deprecated setting: https://www.mediawiki.org/wiki/Manual:$wgAllowImageTag
+	'wgAllowImageTag' => [
+		'default' => false,
+		'dgck81lnnwiki' => true,
+	],
 ];
 
 // Start settings requiring external dependency checks/functions


### PR DESCRIPTION
Requested on Phabricator: https://phabricator.miraheze.org/T10446.