### PR TITLE
Remove metawiki autopatrol protection level + rename

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4217,7 +4217,7 @@ $wgConf->settings += [
 			'edittemplateprotected',
 		],
 		'metawiki' => [
-			'autopatrolled',
+			'editautopatrolprotected',
 		],
 		'naasgamelandwiki' => [
 			'editarchiveprotected',
@@ -4238,8 +4238,8 @@ $wgConf->settings += [
 			'edittemplate',
 		],
 		'testwiki' => [
-			'bureaucrat',
-			'consul',
+			'editbureaucratprotected',
+			'editconsulprotected',
 		],
 		'trwdeploymentwiki' => [
 			'bureaucrat',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2670,9 +2670,6 @@ $wgConf->settings += [
 			],
 		],
 		'+metawiki' => [
-			'autopatrolled' => [
-				'autopatrolled' => true,
-			],
 			'confirmed' => [
 				'mwoauthproposeconsumer' => true,
 				'mwoauthupdateownconsumer' => true,
@@ -2700,6 +2697,7 @@ $wgConf->settings += [
 				'managewiki' => true,
 				'managewiki-restricted' => true,
 				'noratelimit' => true,
+				'oathauth-verify-user' => true,
 				'userrights' => true,
 				'userrights-interwiki' => true,
 				'globalgroupmembership' => true,
@@ -2729,7 +2727,6 @@ $wgConf->settings += [
 			],
 			'sysop' => [
 				'interwiki' => true,
-				'autopatrolled' => true,
 			],
 			'user' => [
 				'request-import-dump' => true,
@@ -4038,6 +4035,7 @@ $wgConf->settings += [
 	],
 
 	// Restriction types
+	// Per wmfphab:T230103, they should ideally follow the format of editXXprotected
 	'wgRestrictionLevels' => [
 		'default' => [
 			'',
@@ -4114,7 +4112,7 @@ $wgConf->settings += [
 			'edittemplateprotected',
 		],
 		'+metawiki' => [
-			'autopatrolled',
+			'editautopatrolprotected',
 		],
 		'+moviepediawiki' => [
 			'bureaucrat',
@@ -4135,8 +4133,8 @@ $wgConf->settings += [
 			'edittemplate',
 		],
 		'+testwiki' => [
-			'bureaucrat',
-			'consul',
+			'editbureaucratprotected',
+			'editconsulprotected',
 		],
 		'+theredpionnerwiki' => [
 			'extendedconfirmed',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4035,7 +4035,7 @@ $wgConf->settings += [
 	],
 
 	// Restriction types
-	// Per wmfphab:T230103, they should ideally follow the format of editXXprotected
+	// For i18n purposes, custom types should ideally follow the format of editXXprotected
 	'wgRestrictionLevels' => [
 		'default' => [
 			'',


### PR DESCRIPTION
- Removes metawiki autopatrolled protection level, will be assigned via ManageWiki instead for easy controlling
- Renames autopatrolled level to editautopatrolprotected
- Renames consul and bureaucrat protection level to editconsulprotected and editbureaucratprotected, per wmfphab:T230103