### PR TITLE
add viewsuppressed to oversight

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2528,6 +2528,7 @@ $wgConf->settings += [
 				'hideuser' => true,
 				'suppressionlog' => true,
 				'suppressrevision' => true,
+				'viewsuppressed' => true,
 			],
 			'steward' => [
 				'userrights' => true,


### PR DESCRIPTION
seems to be a bug in MW 1.39 that suppressrevision no longer allows one to view (or modify the suppressed status of) suppressed revisions.