### PR TITLE
Move main cache and message cache to memcached-mem-1

### DIFF
--- a/GlobalCache.php
+++ b/GlobalCache.php
@@ -91,8 +91,8 @@ $wgMWOAuthSessionCacheType = 'db-replicated';
 
 $redisServerIP = '[2a10:6740::6:306]:6379';
 
-$wgMainCacheType = 'memcached-mem-2';
-$wgMessageCacheType = 'memcached-mem-2';
+$wgMainCacheType = 'memcached-mem-1';
+$wgMessageCacheType = 'memcached-mem-1';
 
 $wgParserCacheType = 'mysql-multiwrite';
 


### PR DESCRIPTION
Leave only session cache on memcached-mem-2, as my idea for the reason session loss is happening lately (T10456) is that memcached usage has increased, leading to key evictions and loss of session cache.