### PR TITLE
Fix Kartographer configurations for hkrailwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2004,8 +2004,8 @@ $wgConf->settings += [
 			'templatewikiarchive',
 		],
 		'+hkrailwiki' => [
-			'hkrailfan',
 			'zhwikipedia',
+			'hkrailfan',
 		],
 		'+incubatorwiki' => [
 			'wmincubator',
@@ -2128,6 +2128,7 @@ $wgConf->settings += [
 		'bluepageswiki' => '.',
 		'gratisdatawiki' => '.',
 		'gratispaideiawiki' => '.',
+		'hkrailwiki' => '.',
 		'leborkwiki' => '.',
 	],
 	'wgKartographerEnableMapFrame' => [
@@ -2147,6 +2148,9 @@ $wgConf->settings += [
 		'bluepageswiki' => [
 			1,
 		],
+		'hkrailwiki' => [
+			1,
+		],
 		'leborkwiki' => [
 			1,
 		],
@@ -2158,6 +2162,7 @@ $wgConf->settings += [
 		'default' => true,
 		'bluepageswiki' => false,
 		'gratisdatawiki' => false,
+		'hkrailwiki' => false,
 		'leborkwiki' => false,
 	],
 	'wgKartographerStyles' => [


### PR DESCRIPTION
Same case on hkrailwiki with leborkwiki and bluepageswiki ([T10430](https://phabricator.miraheze.org/T10430), [T10445](https://phabricator.miraheze.org/T10445), [T10547](https://phabricator.miraheze.org/T10547)), Kartographer default settings by default causes 400 errors.
Also reordering import options for hkrailwiki in the order of common usage.