### PR TITLE
add new createCargoDB.php to cargo install

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5704,6 +5704,9 @@ if ( $wi->missing ) {
 require_once '/srv/mediawiki/config/GlobalSettings.php';
 require_once '/srv/mediawiki/config/LocalWiki.php';
 
+// Configure late to ensure $wgDBname is set properly
+$wgCargoDBname = $wgDBname . 'cargo';
+
 // Define last - Extension message files for loading extensions
 if (
 	file_exists( __DIR__ . '/ExtensionMessageFiles.php' ) &&

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -421,3 +421,5 @@ switch ( $wi->dbname ) {
 
 		break;
 }
+
+$wgCargoDBname = $wgDBname . 'cargo';

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -421,5 +421,3 @@ switch ( $wi->dbname ) {
 
 		break;
 }
-
-$wgCargoDBname = $wgDBname . 'cargo';

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -272,6 +272,9 @@ $wgManageWikiExtensions = [
 			],
 		],
 		'install' => [
+			'mwscript' => [
+				'$IP/extensions/MirahezeMagic/maintenance/createCargoDB.php' => [],
+			],
 			'sql' => [
 				'cargo_tables' => "$IP/extensions/Cargo/sql/Cargo.sql",
 				'cargo_backlinks' => "$IP/extensions/Cargo/sql/cargo_backlinks.sql"

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -273,7 +273,7 @@ $wgManageWikiExtensions = [
 		],
 		'install' => [
 			'mwscript' => [
-				'$IP/extensions/MirahezeMagic/maintenance/createCargoDB.php' => [],
+				"$IP/extensions/MirahezeMagic/maintenance/createCargoDB.php" => [],
 			],
 			'sql' => [
 				'cargo_tables' => "$IP/extensions/Cargo/sql/Cargo.sql",


### PR DESCRIPTION
Includes configuration of $wgCargoDBname to be equal to `$wgDBname . 'cargo'`

Intended for use with https://github.com/miraheze/MirahezeMagic/pull/413