### PR TITLE
Modifying $wgAvailableRights and $wgRestrictionLevels

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4133,7 +4133,7 @@ $wgConf->settings += [
 			'edittemplateprotected',
 		],
 		'+hypopediawiki' => [
-			'bureaucrat',
+			'editbureaucratprotected',
 			'editextendedconfirmedprotected',
 		],
 		'+igrovyesistemywiki' => [
@@ -4176,6 +4176,11 @@ $wgConf->settings += [
 		],
 		'+sesupportwiki' => [
 			'editor',
+		],
+		'+scratchpadwiki' => [
+			'editbureaucratprotected',
+			'editextendedconfirmedprotected',
+			'edittemplateprotected',
 		],
 		'+simulatorwiki' => [
 			'edittemplate',
@@ -4246,6 +4251,7 @@ $wgConf->settings += [
 			'edittemplateprotected',
 		],
 		'hypopediawiki' => [
+			'editbureaucratprotected',
 			'editextendedconfirmedprotected',
 		],
 		'infopediawiki' => [
@@ -4280,6 +4286,11 @@ $wgConf->settings += [
 		],
 		'projectsekaiwiki' => [
 			'editguide',
+		],
+		'scratchpadwiki' => [
+			'editbureaucratprotected',
+			'editextendedconfirmedprotected',
+			'edittemplateprotected',
 		],
 		'simulatorwiki' => [
 			'editfragment',


### PR DESCRIPTION
This is to add custom protection levels to the Scratchpad Wiki. Usually, I would request this on Phabricator, but it is not working correctly, at least at the time I submitted this. I also modified Hypopedia's too as relevant.