### PR TITLE
Remove IPInfo extension T10754

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -23,7 +23,6 @@ wfLoadExtensions( [
 	'ImportDump',
 	'IncidentReporting',
 	'Interwiki',
-	'IPInfo',
 	'LoginNotify',
 	'ManageWiki',
 	'MatomoAnalytics',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2124,11 +2124,6 @@ $wgConf->settings += [
 		],
 	],
 
-	// IPInfo
-	'wgIPInfoGeoLite2Prefix' => [
-		'default' => '/srv/mediawiki/geoip/GeoLite2-',
-	],
-
 	// JavascriptSlideshow
 	'wgHtml5' => [
 		'ext-JavascriptSlideshow' => true,
@@ -2896,10 +2891,6 @@ $wgConf->settings += [
 				'hideuser',
 				'interwiki',
 				'investigate',
-				'ipinfo',
-				'ipinfo-view-basic',
-				'ipinfo-view-full',
-				'ipinfo-view-log',
 				'managewiki-restricted',
 				'managewiki-editdefault',
 				'moderation-checkuser',


### PR DESCRIPTION
Doesn't work on Miraheze (and apparently will need premium features to be functional) and it's generating a rather clumsy user group that no one can use. CheckUser should be sufficient for related tasks.