### PR TITLE
Create global-renamer group on Meta

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2722,6 +2722,9 @@ $wgConf->settings += [
 				'mwoauthproposeconsumer' => true,
 				'mwoauthupdateownconsumer' => true,
 			],
+			'global-renamer' => [
+				'centralauth-rename' => true,
+			],
 			'global-sysop' => [
 				'abusefilter-modify-global' => true,
 				'centralauth-lock' => true,


### PR DESCRIPTION
Following a discussion with Reception123 and due to technical issues with CentralAuth and accounts being attached to too many wikis loading slowly, this group is created for Stewards only to assign to their alts