### PR TITLE
Changes to CentralAuth config

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -387,9 +387,6 @@ $wgConf->settings += [
 			'betawiki',
 		],
 	],
-	'wgCentralAuthAutoNew' => [
-		'default' => true,
-	],
 	'wgCentralAuthAutoMigrate' => [
 		'default' => true,
 	],
@@ -419,14 +416,23 @@ $wgConf->settings += [
 	'wgCentralAuthEnableGlobalRenameRequest' => [
 		'default' => true,
 	],
+	'wgCentralAuthGlobalBlockInterwikiPrefix' => [
+		'default' => 'meta',
+	],
 	'wgCentralAuthLoginWiki' => [
 		'default' => 'loginwiki',
 		'betaheze' => 'betawiki',
 	],
+	'wgCentralAuthOldNameAntiSpoofWiki' => [
+		'default' => 'metawiki',
+	],
 	'wgCentralAuthPreventUnattached' => [
 		'default' => true,
 	],
-	'wgCentralAuthSilentLogin' => [
+	'wgGlobalRenameDenylist' => [
+		'default' => 'https://meta.miraheze.org/w/index.php?title=MediaWiki:Global_rename_blacklist&action=raw',
+	],
+	'wgGlobalRenameDenylistRegex' => [
 		'default' => true,
 	],
 


### PR DESCRIPTION
This PR has removed old CentralAuth configurations which have been removed for a while like wgCentralAuthSilentLogin and wgCentralAuthAutoNew (compare with https://github.com/wikimedia/mediawiki-extensions-CentralAuth/blob/REL1_39/extension.json).

This PR also sets wgCentralAuthGlobalBlockInterwikiPrefix to to the "meta" interwiki prefix to link global blocker user page links to Meta and also sets wgCentralAuthOldNameAntiSpoofWiki to "metawiki" to check Meta's AntiSpoof database instead of the local database for possible impersonations following renames.

Also enables a global rename denylist.