### PR TITLE
Modify $wgAvailableRights and $wgRestrictionLevels

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4150,6 +4150,7 @@ $wgConf->settings += [
                         'autoconfirmed',
 			'templateeditor',
 			'extendedconfirmed',
+			'moderator',
 			'sysop',
 			'bureaucrat',
 		],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4145,9 +4145,13 @@ $wgConf->settings += [
 			'editor',
 		],
 		'+scratchpadwiki' => [
-			'editbureaucratprotected',
-			'editextendedconfirmedprotected',
-			'edittemplateprotected',
+			'',
+			'user',
+                        'autoconfirmed',
+			'templateeditor',
+			'extendedconfirmed',
+			'sysop',
+			'bureaucrat',
 		],
 		'+simulatorwiki' => [
 			'edittemplate',
@@ -4258,9 +4262,10 @@ $wgConf->settings += [
 			'editguide',
 		],
 		'scratchpadwiki' => [
-			'editbureaucratprotected',
-			'editextendedconfirmedprotected',
-			'edittemplateprotected',
+			'templateeditor',
+			'extendedconfirmed',
+			'moderator',
+			'bureaucrat',
 		],
 		'simulatorwiki' => [
 			'editfragment',


### PR DESCRIPTION
I want to modify these restriction levels for the Scratchpad Wiki here on Miraheze and show them in order. I am also adding templateeditor, extendedconfirmed, moderator, and bureaucrat permissions to $wgAvailableRights. I understand that the '', 'user', 'autoconfirmed', and 'sysop' groups are already defined by default, but I want them to be in order on the wiki I'm administrating. Thank you.