### PR TITLE
T10809: Remove user only protection level for nycsubwaywiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4235,6 +4235,11 @@ $wgConf->settings += [
 			'editextendedconfirmedprotected',
 			'edittemplateprotected',
 		],
+		'nycsubwaywiki' => [
+			'',
+			'autoconfirmed',
+			'sysop',
+		],
 		'+sesupportwiki' => [
 			'editor',
 		],


### PR DESCRIPTION
Requested on https://phabricator.miraheze.org/T10809.

Implemented via just copying and pasting the default value of wgRestrictionLevel, then removing (user) and adding it to nycsubwaywiki. The abscense of a + means it won't merge with the default array, so that it doesn't re-add user level protection.