### PR TITLE
Set WebAuthn configuration to allow security key login on all *.miraheze.org

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5117,6 +5117,15 @@ $wgConf->settings += [
 		'default' => '1 hour',
 	],
 
+	// WebAuthn
+	'wgWebAuthnRelyingPartyName' => [
+		'default' => 'Miraheze',
+		'betaheze' => 'Betaheze',
+	],
+	'wgWebAuthnRelyingPartyID' => [
+		'default' => 'miraheze.org',
+		'betaheze' => 'betaheze.org',
+	],
 	// Wikibase
 	'wmgAllowEntityImport' => [
 		'default' => false,


### PR DESCRIPTION
Currently, you can only login with your security key to the wiki you registered on. This change will allow your security key to work on all *.miraheze.org domains (but still not custom domains). i18n should be updated accordingly. I will test this out tomorrow.