### PR TITLE
Revert "Set WebAuthn configuration to allow security key login on all *.miraheze.org"

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5117,15 +5117,6 @@ $wgConf->settings += [
 		'default' => '1 hour',
 	],
 
-	// WebAuthn
-	'wgWebAuthnRelyingPartyName' => [
-		'default' => 'Miraheze',
-		'betaheze' => 'Betaheze',
-	],
-	'wgWebAuthnRelyingPartyID' => [
-		'default' => 'miraheze.org',
-		'betaheze' => 'betaheze.org',
-	],
 	// Wikibase
 	'wmgAllowEntityImport' => [
 		'default' => false,


### PR DESCRIPTION
Reverts miraheze/mw-config#5232

This is temporarily reverted to allow the small subset of users with this enabled to switch to TOTP temporarily or disable it.