### PR TITLE
Enable the Parsoid extension on all wikis

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -34,6 +34,7 @@ wfLoadExtensions( [
 	'OATHAuth',
 	'OAuth',
 	'ParserFunctions',
+	'Parsoid',
 	'QuickInstantCommons',
 	'Renameuser',
 	'RottenLinks',

--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -66,40 +66,36 @@ if ( $wi->isAnyOfExtensionsActive( 'WikibaseClient', 'WikibaseRepository' ) ) {
 	require_once '/srv/mediawiki/config/Wikibase.php';
 }
 
-// If Flow, VisualEditor, or Linter is used, use the Parsoid php extension
-if ( $wi->isAnyOfExtensionsActive( 'Flow', 'VisualEditor', 'Linter' ) ) {
-	wfLoadExtension( 'Parsoid', "$IP/vendor/wikimedia/parsoid/extension.json" );
-
-	if ( $wi->isExtensionActive( 'VisualEditor' ) ) {
-		$wgVisualEditorParsoidAutoConfig = false;
-	}
-
-	$wgVirtualRestConfig = [
-		'paths' => [],
-		'modules' => [
-			'parsoid' => [
-				'url' => 'https://mw-lb.miraheze.org/w/rest.php',
-				'domain' => $wi->server,
-				'prefix' => $wi->dbname,
-				'forwardCookies' => (bool)$cwPrivate,
-				'restbaseCompat' => false,
-				'timeout' => 30,
-			],
-		],
-		'global' => [
-			'timeout' => 360,
-			'forwardCookies' => false,
-			'HTTPProxy' => null,
-		],
-	];
-
-	if ( $wi->isExtensionActive( 'Flow' ) ) {
-		$wgFlowParsoidURL = 'https://mw-lb.miraheze.org/w/rest.php';
-		$wgFlowParsoidPrefix = $wi->dbname;
-		$wgFlowParsoidTimeout = 30;
-		$wgFlowParsoidForwardCookies = (bool)$cwPrivate;
-	}
+if ( $wi->isExtensionActive( 'VisualEditor' ) ) {
+	$wgVisualEditorParsoidAutoConfig = false;
 }
+
+$wgVirtualRestConfig = [
+	'paths' => [],
+	'modules' => [
+	'parsoid' => [
+		'url' => 'https://mw-lb.miraheze.org/w/rest.php',
+		'domain' => $wi->server,
+		'prefix' => $wi->dbname,
+		'forwardCookies' => (bool)$cwPrivate,
+		'restbaseCompat' => false,
+		'timeout' => 30,
+		],
+	],
+	'global' => [
+		'timeout' => 360,
+		'forwardCookies' => false,
+		'HTTPProxy' => null,
+	],
+];
+
+if ( $wi->isExtensionActive( 'Flow' ) ) {
+	$wgFlowParsoidURL = 'https://mw-lb.miraheze.org/w/rest.php';
+	$wgFlowParsoidPrefix = $wi->dbname;
+	$wgFlowParsoidTimeout = 30;
+	$wgFlowParsoidForwardCookies = (bool)$cwPrivate;
+}
+
 
 $wgAllowedCorsHeaders[] = 'X-Miraheze-Debug';
 


### PR DESCRIPTION
Eventually, this will be our main parser. In preparation, let's make it available for everyone.

For now, this will have little impact apart from making the rest API open to all wikis. (Although you shouldn't be rest.php for bots as it isn't stable). In future, wikis will be able to start testing Parsoid for reads which will be coming to Miraheze in about 7 months time.