### PR TITLE
Remove ImportDump and IncidentReports as global extensions

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -20,8 +20,6 @@ wfLoadExtensions( [
 	'EventStreamConfig',
 	'GlobalCssJs',
 	'GlobalNewFiles',
-	'ImportDump',
-	'IncidentReporting',
 	'Interwiki',
 	'IPInfo',
 	'LoginNotify',

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -198,10 +198,6 @@ switch ( $wi->dbname ) {
 		}
 
 		break;
-	case 'loginwiki':
-		wfLoadExtension( 'GlobalWatchlist' );
-
-		break;
 	case 'metawiki':
 		$wgContactConfig = [
 			'default' => [
@@ -318,6 +314,13 @@ switch ( $wi->dbname ) {
 			'timeout' => 3,
 			'type' => 'google',
 		];
+
+		wfLoadExtensions( [
+			'GlobalWatchlist',
+			'ImportDump',
+			'IncidentReports',
+		] );
+
 		break;
 	case 'newusopediawiki':
 		$wgFilterLogTypes['comments'] = false;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -13,10 +13,6 @@ switch ( $wi->dbname ) {
 		$wgJsonConfigs['Tabular.JsonConfig']['store'] = true;
 
 		break;
-	case 'metawikibeta':
-		wfLoadExtension( 'GlobalWatchlist' );
-
-		break;
 	case 'commonswiki':
 		$wgJsonConfigs['Map.JsonConfig']['store'] = true;
 		$wgJsonConfigs['Tabular.JsonConfig']['store'] = true;
@@ -318,8 +314,12 @@ switch ( $wi->dbname ) {
 		wfLoadExtensions( [
 			'GlobalWatchlist',
 			'ImportDump',
-			'IncidentReports',
+			'IncidentReporting',
 		] );
+
+		break;
+	case 'metawikibeta':
+		wfLoadExtension( 'GlobalWatchlist' );
 
 		break;
 	case 'newusopediawiki':


### PR DESCRIPTION
They should only be loaded on Meta as that's where they're used exclusively.