### PR TITLE
Remove WikiForum from ManageWiki (T10871)

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -308,9 +308,6 @@ $wgConf->settings += [
 			'badlogin' => true,
 			'badloginperuser' => true
 		],
-		'+ext-WikiForum' => [
-			'wikiforum' => true,
-		],
 	],
 	'wgHCaptchaSiteKey' => [
 		'default' => 'e6d26503-a3fb-47fb-9639-efe259a34a33',
@@ -5506,15 +5503,7 @@ $wgConf->settings += [
 	'wgWikiEditorRealtimePreview' => [
 		'default' => false,
 	],
-
-	// WikiForum
-	'wgWikiForumAllowAnonymous' => [
-		'default' => true,
-	],
-	'wgWikiForumLogsInRC' => [
-		'default' => true,
-	],
-
+	
 	// WikiDiscover
 	'wgWikiDiscoverUseDescriptions' => [
 		'default' => true,

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -3529,41 +3529,6 @@ $wgManageWikiExtensions = [
 		'requires' => [],
 		'section' => 'other',
 	],
-	'wikiforum' => [
-		'name' => 'WikiForum',
-		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiForum',
-		'var' => 'wmgUseWikiForum',
-		'conflicts' => false,
-		'requires' => [],
-		'install' => [
-			'sql' => [
-				'wikiforum_forums' => "$IP/extensions/WikiForum/sql/wikiforum.sql"
-			],
-			'permissions' => [
-				'bureaucrat' => [
-					'addgroups' => [
-						'forumadmin',
-					],
-					'removegroups' => [
-						'forumadmin',
-					],
-				],
-				'forumadmin' => [
-					'permissions' => [
-						'wikiforum-admin',
-						'wikiforum-moderator',
-					],
-				],
-				'sysop' => [
-					'permissions' => [
-						'wikiforum-admin',
-						'wikiforum-moderator',
-					],
-				],
-			],
-		],
-		'section' => 'other',
-	],
 	'wikilove' => [
 		'name' => 'WikiLove',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiLove',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -531,15 +531,6 @@ $wgManageWikiSettings = [
 		'help' => 'This sets the web client to use. If you are not using Libera, select Other Server.',
 		'requires' => [],
 	],
-	'wgWikiForumAllowAnonymous' => [
-		'name' => 'WikiForum Allow Anonymous',
-		'from' => 'wikiforum',
-		'type' => 'check',
-		'overridedefault' => true,
-		'section' => 'discussion',
-		'help' => 'Allow Anonymous (users who are not logged in) to use WikiForum',
-		'requires' => [],
-	],
 
 	// Editing
 	'wmgWikiLicense' => [


### PR DESCRIPTION
This PR removes WikiForum from ManageWiki configuration and thus, prevents users from enabling it. It also removes associated settings from ManageWiki and LocalSettings.php. 

This addresses [T10871](https://phabricator.miraheze.org/T10871).