### PR TITLE
Turn on DiscussionTools enhancements in isvwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1213,6 +1213,20 @@ $wgConf->settings += [
 		'default' => 'en',
 	],
 
+	// DiscussionTools
+	'wgDiscussionTools_visualenhancements' => [
+		'isvwiki' => 'available',
+	],
+	'wgDiscussionTools_visualenhancements_reply' => [
+		'isvwiki' => 'available',
+	],
+	'wgDiscussionTools_visualenhancements_pageframe' => [
+		'isvwiki' => 'available',
+	],
+	'wgDiscussionTools_visualenhancements_newsectionlink_enable' => [
+		'isvwiki' => 'available',
+	],
+
 	// Description2
 	'wgEnableMetaDescriptionFunctions' => [
 		'ext-Description2' => true,


### PR DESCRIPTION
I am not sure if `'default'` is required here. If it is, I can fix the patch. I followed https://noc.wikimedia.org/conf/InitialiseSettings.php.txt on variable names and values.