### PR TITLE
Change wgSVGConverter to use rsvg

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -554,6 +554,7 @@ $wgMaxShellTime = 50;
 $wgShellCgroup = '/sys/fs/cgroup/memory/mediawiki/job';
 
 $wgJobRunRate = 0;
+$wgSVGConverters['rsvg'] = '$path/mediawiki-firejail-rsvg-convert -w $width -h $height -o $output $input';
 
 // We need all thumbs to be regenerated
 $wgThumbnailEpoch = 20230715011058;

--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -555,6 +555,7 @@ $wgShellCgroup = '/sys/fs/cgroup/memory/mediawiki/job';
 
 $wgJobRunRate = 0;
 $wgSVGConverters['inkscape'] = '$path/inkscape -w $width -o $output $input';
+$wgSVGConverters['rsvg-secure'] = '$path/rsvg-convert --no-external-files -w $width -h $height -o $output $input';
 
 // We need all thumbs to be regenerated
 $wgThumbnailEpoch = 20230715011058;

--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -554,7 +554,6 @@ $wgMaxShellTime = 50;
 $wgShellCgroup = '/sys/fs/cgroup/memory/mediawiki/job';
 
 $wgJobRunRate = 0;
-$wgSVGConverters['inkscape'] = '$path/inkscape -w $width -o $output $input';
 $wgSVGConverters['rsvg-secure'] = '$path/rsvg-convert --no-external-files -w $width -h $height -o $output $input';
 
 // We need all thumbs to be regenerated

--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -554,7 +554,6 @@ $wgMaxShellTime = 50;
 $wgShellCgroup = '/sys/fs/cgroup/memory/mediawiki/job';
 
 $wgJobRunRate = 0;
-$wgSVGConverters['rsvg-secure'] = '$path/rsvg-convert --no-external-files -w $width -h $height -o $output $input';
 
 // We need all thumbs to be regenerated
 $wgThumbnailEpoch = 20230715011058;

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1583,7 +1583,7 @@ $wgConf->settings += [
 		'default' => 262144,
 	],
 	'wgSVGConverter' => [
-		'default' => 'rsvg-secure',
+		'default' => 'rsvg',
 	],
 	'wgUploadMissingFileUrl' => [
 		'default' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1583,7 +1583,7 @@ $wgConf->settings += [
 		'default' => 262144,
 	],
 	'wgSVGConverter' => [
-		'default' => 'ImageMagick',
+		'default' => 'rsvg-secure',
 	],
 	'wgUploadMissingFileUrl' => [
 		'default' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1585,6 +1585,9 @@ $wgConf->settings += [
 	'wgSVGConverter' => [
 		'default' => 'rsvg',
 	],
+	'wgSVGConverterPath' => [
+		'default' => '/usr/bin'
+	],
 	'wgUploadMissingFileUrl' => [
 		'default' => false,
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1588,7 +1588,7 @@ $wgConf->settings += [
 		'default' => 'rsvg',
 	],
 	'wgSVGConverterPath' => [
-		'default' => '/usr/bin'
+		'default' => '/usr/local/bin'
 	],
 	'wgUploadMissingFileUrl' => [
 		'default' => false,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1291,20 +1291,6 @@ $wgManageWikiSettings = [
 		'help' => 'Toggles native image lazy loading, via the "loading" attribute.',
 		'requires' => [],
 	],
-	'wgSVGConverter' => [
-		'name' => 'SVG Converter',
-		'from' => 'mediawiki',
-		'global' => true,
-		'type' => 'list',
-		'options' => [
-			'Inkscape' => 'inkscape',
-			'ImageMagick' => 'ImageMagick',
-		],
-		'overridedefault' => 'ImageMagick',
-		'section' => 'media',
-		'help' => 'This picks the converter to convert Scalable Vector Graphics (SVG) to PNG. You may want to choose Inkscape if your SVG->PNG conversion results in a black image.',
-		'requires' => [],
-	],
 	'wgMediaViewerEnableByDefault' => [
 		'name' => 'MediaViewer Enable By Default',
 		'from' => 'multimediaviewer',


### PR DESCRIPTION
Remove wgSVGConverter from ManageWiki as we only want one option and to default to it as well.