### PR TITLE
Add class extiw for extension LinkTarget 

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2457,9 +2457,9 @@ $wgConf->settings += [
 			[ 'newtablinks', 'wikiwalk' ],
 			'_self' => [ 'sametablinks' ]
 		],
-		'sdiywiki' => '_blank' => [ 'extiw' ],
-		'scruffywiki' => '_blank' => [ 'extiw' ],
-		'simpleelectronicswiki' => '_blank' => [ 'extiw' ]
+		'sdiywiki' => ['_blank' => [ 'extiw' ]],
+		'scruffywiki' => ['_blank' => [ 'extiw' ]],
+		'simpleelectronicswiki' => ['_blank' => [ 'extiw' ]]
 	],
 
 	// LinkTitles

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2457,6 +2457,9 @@ $wgConf->settings += [
 			[ 'newtablinks', 'wikiwalk' ],
 			'_self' => [ 'sametablinks' ]
 		],
+		'sdiywiki' => '_blank' => [ 'extiw' ],
+		'scruffywiki' => '_blank' => [ 'extiw' ],
+		'simpleelectronicswiki' => '_blank' => [ 'extiw' ]
 	],
 
 	// LinkTitles


### PR DESCRIPTION
Add class extiw for [extension LinkTarget](https://www.mediawiki.org/wiki/Extension:LinkTarget) on sdiywiki, scruffywiki and simpleelectronicswiki as per [T11084](https://phabricator.miraheze.org/T11084), [T11101](https://phabricator.miraheze.org/T11101) and [T11102](https://phabricator.miraheze.org/T11102).

Trying to get target="_blank" on interwiki links.