### PR TITLE
Set wgExportMaxHistory to 1000

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2111,6 +2111,10 @@ $wgConf->settings += [
 		],
 	],
 
+	'wgExportMaxHistory' => [
+		'default' => 1000
+	],
+
 	// IPInfo
 	'wgIPInfoGeoLite2Prefix' => [
 		'default' => '/srv/mediawiki/geoip/GeoLite2-',


### PR DESCRIPTION
Large wikis can cause problems when this value is set to 0 (default).