### PR TITLE
Don't use Renameuser on mw 1.40+ as it's bundled into core now

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -33,7 +33,6 @@ wfLoadExtensions( [
 	'OAuth',
 	'ParserFunctions',
 	'QuickInstantCommons',
-	'Renameuser',
 	'RottenLinks',
 	'Scribunto',
 	// 'SecureLinkFixer',
@@ -46,5 +45,10 @@ wfLoadExtensions( [
 	'WikiEditor',
 	'cldr',
 ] );
+
+// Renameuser is bundled into core from 1.40+
+if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+	wfLoadExtensions( 'Renameuser' );
+}
 
 wfLoadExtension( 'Parsoid', "$IP/vendor/wikimedia/parsoid/extension.json" );


### PR DESCRIPTION
Bug: T10701