### PR TITLE
Set wgCookieSameSite and wgUseSameSiteLegacyCookies

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -11,6 +11,9 @@ if ( $wi->dbname !== 'ldapwikiwiki' && $wi->dbname !== 'srewiki' ) {
 		'GlobalBlocking',
 		'RemovePII',
 	] );
+
+	$wgCookieSameSite = 'None';
+	$wgUseSameSiteLegacyCookies = true;
 }
 
 if ( $wi->isExtensionActive( 'chameleon' ) ) {

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -454,10 +454,10 @@ switch ( $wi->dbname ) {
 		$wgDplSettings['allowUnlimitedResults'] = true;
 
 		break;
-	case 'whentheycrywiki': 
+	case 'whentheycrywiki':
 		$wgGalleryOptions['imageWidth'] = 200;
 		$wgGalleryOptions['imageHeight'] = 200;
-			
+
 		break;
 	case 'wonderingstarswiki':
 		$wgPivotFeatures = [


### PR DESCRIPTION
Fix "Universal sign-on may be broken in newer Google Chrome versions due to SameSite cookie policy" by setting wgCookieSameSite and wgUseSameSiteLegacyCookies.