### PR TITLE
Remove $wgCentralAuthCreateOnView (T9913)

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -442,15 +442,6 @@ $wgConf->settings += [
 		'default' => 'centralauth_',
 		'mirabeta' => 'betacentralauth_',
 	],
-	'wgCentralAuthCreateOnView' => [
-		'default' => true,
-		'cvtwiki' => false,
-		'cwarswiki' => false,
-		'minecraftjapanwiki' => false,
-		'nenawikiwiki' => false,
-		'staffwiki' => false,
-		'stewardswiki' => false
-	],
 	'wgCentralAuthDatabase' => [
 		'default' => 'mhglobal',
 		'mirabeta' => 'testglobal',


### PR DESCRIPTION
$wgCentralAuthCreateOnView has been removed in 1.40 and thus now does nothing.