### PR TITLE
Increase wgMaxUploadSize to 4gb

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1527,8 +1527,7 @@ $wgConf->settings += [
 		'default' => true,
 	],
 	'wgMaxUploadSize' => [
-		/** T3797 - 250MB */
-		'default' => 1024 * 1024 * 250,
+		'default' => 1024 * 1024 * 4096,
 		/** T9673 - 10MB */
 		'dragdownwiki' => 1024 * 1024 * 10,
 	],


### PR DESCRIPTION
php enforces our 250mb limit. Although we should probably lower it to 100mb. If people need to upload a larger file they could open a task and we could do it.