### PR TITLE
Send "Cache-control: no-cache" header by default

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -10,6 +10,10 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
 }
 
+if ( PHP_SAPI !== 'cli' ) {
+	header( "Cache-control: no-cache" );
+}
+
 setlocale( LC_ALL, 'en_GB.UTF-8' );
 
 // 1400MiB


### PR DESCRIPTION
Does not do it on cli and MediaWiki will override it where appropriate.