### PR TITLE
Disable PageProperties globally

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6156,6 +6156,7 @@ $wi::$disabledExtensions = [
 	'wikiforum',
 	// T10756
 	'graph',
+	// T11641
 	'pageproperties'
 ];
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6156,6 +6156,7 @@ $wi::$disabledExtensions = [
 	'wikiforum',
 	// T10756
 	'graph',
+	'pageproperties'
 ];
 
 if ( $wi->version >= 1.40 ) {


### PR DESCRIPTION
Disable PageProperties globally due to issues and pending a security review.