### PR TITLE
T11040: Create $wmgMirahezeContactPageFooter

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -17,8 +17,8 @@ if ( $wmgMirahezeContactPageFooter && $wi->isExtensionActive( 'ContactPage' ) ) 
 				],
 			$skin->msg( 'contactpage-label' )->text()
 			);
-		}
-	}
+		};
+	};
 }
 
 // Extensions

--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -6,6 +6,21 @@ $wgHooks['ManageWikiCoreFormSubmission'][] = 'MirahezeFunctions::onManageWikiCor
 $wgHooks['MediaWikiServices'][] = 'MirahezeFunctions::onMediaWikiServices';
 $wgHooks['CreateWikiJsonBuilder'][] = 'MirahezeFunctions::onCreateWikiJsonBuilder';
 
+if ( $wmgMirahezeContactPageFooter && $wi->isExtensionActive( 'ContactPage' ) ) {
+
+	$wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$footerlinks ) {
+		if ( $key === 'places' ) {
+			$footerlinks['contact'] = Html::element( 'a',
+				[
+					'href' => sprintf('%s/wiki/Special:Contact', $wgServer),
+					'rel' => 'noreferrer noopener'
+				],
+			$skin->msg( 'contactpage-label' )->text()
+			);
+		}
+	}
+}
+
 // Extensions
 if ( $wi->dbname !== 'ldapwikiwiki' && $wi->dbname !== 'srewiki' ) {
 	wfLoadExtensions( [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6214,7 +6214,7 @@ $wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$fo
 		if ( $key === 'places' ) {
 			$footerlinks['contact'] = Html::element( 'a',
 				[
-					'href' => sprintf('%s/wiki/Special:Contact', $wgServer),  // URL to "Special:Contact"
+					'href' => sprintf('%s/wiki/Special:Contact', $wgServer),
 					'rel' => 'noreferrer noopener'
 				],
 			$skin->msg( 'contactpage-label' )->text()

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -646,6 +646,10 @@ $wgConf->settings += [
 	'wmgContactPageRecipientUser' => [
 		'default' => null,
 	],
+	//Used to add a link to Special:Contact on the footer, not from extension
+	'wmgMirahezeContactPageFooter' => [
+		'default' => false,
+	],
 
 	// Contribution Scores
 	'wgContribScoreDisableCache' => [
@@ -6202,6 +6206,21 @@ if ( $wi->missing ) {
 	require_once '/srv/mediawiki/ErrorPages/MissingWiki.php';
 }
 
+// ManageWiki-controlled hooks
+
+$wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$footerlinks ) {
+	if ( $wmgMirahezeContactPageFooter ) {
+		if ( $key === 'places' ) {
+			$footerlinks['contact'] = Html::element( 'a',
+				[
+					'href' => sprintf('%s/wiki/Special:Contact', $wgServer),  // URL to "Special:Contact"
+					'rel' => 'noreferrer noopener'
+				],
+			$skin->msg( 'contactpage-label' )->text()
+			);
+		};
+	};
+};
 // Define last to avoid all dependencies
 require_once '/srv/mediawiki/config/GlobalSettings.php';
 require_once '/srv/mediawiki/config/LocalWiki.php';

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6207,21 +6207,6 @@ if ( $wi->missing ) {
 	require_once '/srv/mediawiki/ErrorPages/MissingWiki.php';
 }
 
-// ManageWiki-controlled hooks
-
-$wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$footerlinks ) {
-	if ( $wmgMirahezeContactPageFooter ) {
-		if ( $key === 'places' ) {
-			$footerlinks['contact'] = Html::element( 'a',
-				[
-					'href' => sprintf('%s/wiki/Special:Contact', $wgServer),
-					'rel' => 'noreferrer noopener'
-				],
-			$skin->msg( 'contactpage-label' )->text()
-			);
-		};
-	};
-};
 // Define last to avoid all dependencies
 require_once '/srv/mediawiki/config/GlobalSettings.php';
 require_once '/srv/mediawiki/config/LocalWiki.php';

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -646,6 +646,7 @@ $wgConf->settings += [
 	'wmgContactPageRecipientUser' => [
 		'default' => null,
 	],
+
 	//Used to add a link to Special:Contact on the footer, not from extension
 	'wmgMirahezeContactPageFooter' => [
 		'default' => false,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1104,6 +1104,15 @@ $wgManageWikiSettings = [
 		'help' => 'Source to get the page description from.',
 		'requires' => [],
 	],
+	'wmgMirahezeContactPageFooter' => [
+		'name' => 'Miraheze Contact Page Footer',
+		'from' => 'contactpage',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'links',
+		'help' => 'If set, it adds a link to Special:Contact on the footer',
+		'requires' => [],
+	],
 
 	// Localisation (E.G i18n/timezone etc)
 	'wgLocaltimezone' => [


### PR DESCRIPTION
This variable is used for a hook that adds a link to the wiki's Special:Contact page to the footer.

While in ManageWiki it is set as a variable from the ContactPage extension, it is not. It's set like that so that it will only appear if ContactPage is enabled

As of writing, I'm not sure of the naming convention or where the hook should be, so I set it to wmgMirahezeContactPageFooter and added it to LocalSettings.php, respectively. I don't see any examples to go off by anyway.