### PR TITLE
T11673: Add wgCitizenGlobalToolsPortlet & remove wgCitizenPortalAttach

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -585,7 +585,7 @@ $wgConf->settings += [
 		'default' => true,
 	],
 	'wgCitizenGlobalToolsPortlet' => [
-		'defauklt' => '',
+		'default' => '',
 	],
 	'wgCitizenShowPageTools' => [
 		'default' => 1,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -584,8 +584,8 @@ $wgConf->settings += [
 	'wgCitizenEnableCollapsibleSections' => [
 		'default' => true,
 	],
-	'wgCitizenPortalAttach' => [
-		'default' => 'first',
+	'wgCitizenGlobalToolsPortlet' => [
+		'defauklt' => '',
 	],
 	'wgCitizenShowPageTools' => [
 		'default' => 1,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3490,6 +3490,15 @@ $wgManageWikiSettings = [
 		'help' => 'Enables or disable collapsible sections on content pages.',
 		'requires' => [],
 	],
+	'wgCitizenGlobalToolsPortlet' => [
+		'name' => 'Citizen Global Tools Portlet',
+		'from' => 'citizen',
+		'type' => 'text',
+		'overridedefault' => '',
+		'section' => 'styling',
+		'help' => 'ID of the portlet to attach the global tools',
+		'requires' => [],
+	]
 	'wgCitizenShowPageTools' => [
 		'name' => 'Citizen Show Page Tools',
 		'from' => 'citizen',
@@ -3502,15 +3511,6 @@ $wgManageWikiSettings = [
 		'overridedefault' => 1,
 		'section' => 'styling',
 		'help' => 'The condition of page tools visibility.',
-		'requires' => [],
-	],
-	'wgCitizenPortalAttach' => [
-		'name' => 'Citizen Portal Attach',
-		'from' => 'citizen',
-		'type' => 'text',
-		'overridedefault' => 'first',
-		'section' => 'styling',
-		'help' => 'Label of the portal to attach links to upload and special pages to.',
 		'requires' => [],
 	],
 	'wgCitizenThemeColor' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3498,7 +3498,7 @@ $wgManageWikiSettings = [
 		'section' => 'styling',
 		'help' => 'ID of the portlet to attach the global tools',
 		'requires' => [],
-	]
+	],
 	'wgCitizenShowPageTools' => [
 		'name' => 'Citizen Show Page Tools',
 		'from' => 'citizen',


### PR DESCRIPTION
See https://phabricator.miraheze.org/T11673

wgCitizenPortalAttach was removed from Citizen. Default value for wgCitizenGlobalToolsPortlet and the help string are from https://github.com/StarCitizenTools/mediawiki-skins-Citizen/blob/e985f863bc00c2158fc87f45884efc13a3b92478/skin.json#L619-L620