### PR TITLE
Disable RatePage Temorarily

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6304,7 +6304,8 @@ $wi::$disabledExtensions = [
 	// T11641
 	'pageproperties',
 	// Broken, once again...
-	'lingo'
+	'lingo',
+	'ratepage',
 ];
 
 if ( $wi->version >= 1.40 ) {


### PR DESCRIPTION
Extension does not work on MW 1.41