### PR TITLE
Only show errors when running runJobs from inside jobrunner

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -714,7 +714,7 @@ $wgMathMathMLUrl = 'http://10.0.18.106:10044/';
 $wgHCaptchaProxy = 'http://bastion.wikitide.net:8080';
 $wgCaptchaStorageClass = MediaWiki\Extension\ConfirmEdit\Store\CaptchaCacheStore::class;
 
-if ( getenv( 'JOBRUNNER_RUN' ) && str_contains( $_SERVER['SCRIPT_FILENAME'], 'runJobs.php' ) ) {
+if ( getenv( 'JOBRUNNER_RUN' ) ) {
 	// fatals but not random I/O warnings
 	error_reporting( E_ERROR );
 }

--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -713,3 +713,8 @@ $wgMathMathMLUrl = 'http://10.0.18.106:10044/';
 // Needed as the server uses ipv4 only.
 $wgHCaptchaProxy = 'http://bastion.wikitide.net:8080';
 $wgCaptchaStorageClass = MediaWiki\Extension\ConfirmEdit\Store\CaptchaCacheStore::class;
+
+if ( getenv( 'JOBRUNNER_RUN' ) && str_contains( $_SERVER['SCRIPT_FILENAME'], 'runJobs.php' ) ) {
+	// fatals but not random I/O warnings
+	error_reporting( E_ERROR );
+}


### PR DESCRIPTION
Jobrunner croaks on log messages so only log error messages rather than notices and deprecated messages.