### PR TITLE
Delay DeletedWiki.php until after everything else is loaded

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6389,6 +6389,15 @@ if ( $wi->missing ) {
 }
 
 if ( $cwDeleted ) {
+	if ( $wgCommandLineMode ) {
+		wfHandleDeletedWiki();
+	} else {
+		define( 'MW_FINAL_SETUP_CALLBACK', 'wfHandleDeletedWiki' );
+	}
+}
+
+function wfHandleDeletedWiki() {
+	global $wgCommandLineMode, $wgDBname;
 	require_once '/srv/mediawiki/ErrorPages/DeletedWiki.php';
 }
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6397,7 +6397,7 @@ if ( $cwDeleted ) {
 }
 
 function wfHandleDeletedWiki() {
-	global $wgCommandLineMode, $wgDBname;
+	global $wgCommandLineMode, $wgDBname, $wgLocalDatabases;
 	require_once '/srv/mediawiki/ErrorPages/DeletedWiki.php';
 }
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6397,7 +6397,6 @@ if ( $cwDeleted ) {
 }
 
 function wfHandleDeletedWiki() {
-	global $wgCommandLineMode, $wgDBname, $wgLocalDatabases;
 	require_once '/srv/mediawiki/ErrorPages/DeletedWiki.php';
 }
 


### PR DESCRIPTION
So CreateWiki's cacbe can still be reset so that this loads after CreateWiki (and other extensions) are loaded and if a wiki is undeleted it may know that (T11888)