### PR TITLE
Adding semantic drilldown

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1701,6 +1701,17 @@ $wgManageWikiExtensions = [
 		],
 		'section' => 'specialpages',
 	],
+	'semanticdrilldown' => [
+        	'name' => 'Semantic Drilldown',
+        	'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Semantic_Drilldown',
+        	'conflicts' => false,
+        	'requires' => [
+            		'extensions' => [
+                		'semanticmediawiki',
+            		],
+        	],
+        	'section' => 'specialpages',
+    	],
 	'simplechanges' => [
 		'name' => 'SimpleChanges',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:SimpleChanges',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1702,7 +1702,7 @@ $wgManageWikiExtensions = [
 		'section' => 'specialpages',
 	],
 	'semanticdrilldown' => [
-        	'name' => 'Semantic Drilldown',
+        	'name' => 'SemanticDrilldown',
         	'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Semantic_Drilldown',
         	'conflicts' => false,
         	'requires' => [


### PR DESCRIPTION
Adding semantic drilldown. Semantic drilldown is already in mediawiki-repos.yaml, so I assume that no more work is required to add it other than putting it in the managewikiextensions thing.