### PR TITLE
DNM: grant everyone centralauth-merge

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2788,6 +2788,7 @@ $wgConf->settings += [
 		'default' => [
 			'*' => [
 				'autocreateaccount' => true,
+				'centralauth-merge' => true,
 				'read' => true,
 				'oathauth-enable' => true,
 				'viewmyprivateinfo' => true,


### PR DESCRIPTION
Possible fix to an issue where an user's global and local accounts in a wiki have been disconnected