### PR TITLE
Disable Matomo for genshinimpactwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -505,4 +505,10 @@ switch ( $wi->dbname ) {
 		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
 
 		break;
+	case 'genshinimapctwiki':
+		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
+		$wgMatomoAnalyticsDisableJS = true;
+		$wgMatomoAnalyticsDisableCookie = true;
+
+		break;
 }

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -505,7 +505,7 @@ switch ( $wi->dbname ) {
 		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
 
 		break;
-	case 'genshinimapctwiki':
+	case 'genshinimpactwiki':
 		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
 		$wgMatomoAnalyticsDisableJS = true;
 		$wgMatomoAnalyticsDisableCookie = true;


### PR DESCRIPTION
Does not provide any useful data at the moment and just creates more code that has to be loaded by the user's browser. I might enable it in the future if I have any use for it.