### PR TITLE
Disable the automated ImportDump jobs temporarily

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2106,7 +2106,7 @@ $wgConf->settings += [
 		'mirabeta' => 'metawikibeta',
 	],
 	'wgImportDumpEnableAutomatedJob' => [
-		'default' => true,
+		'default' => false,
 	],
 	'wgImportDumpInterwikiMap' => [
 		'default' => [


### PR DESCRIPTION
They're currently malfunctioning, so we'll have to go back to doing the imports manually for now