### PR TITLE
Change the license image to be an svg

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -619,7 +619,7 @@ $wgRightsUrl = 'https://creativecommons.org/licenses/by-sa/4.0/';
  */
 switch ( $wmgWikiLicense ) {
 	case 'arr':
-		$wgRightsIcon = 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/License_icon-copyright-88x31.svg/88px-License_icon-copyright-88x31.svg.png';
+		$wgRightsIcon = 'https://static.miraheze.org/commonswiki/6/67/License_icon-copyright-88x31.svg';
 		$wgRightsText = 'All Rights Reserved';
 		$wgRightsUrl = false;
 		break;


### PR DESCRIPTION
https://kinsta.com/blog/svg-vs-png/

Also the svg on MH Commons has a way smaller file size than the svg on Wikimedia Commons so that's why I'm linking to MH Commons instead