### PR TITLE
Add `wgPortableInfoboxUseFileDescriptionPage`

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4355,6 +4355,9 @@ $wgConf->settings += [
 	'wgPortableInfoboxResponsiblyOpenCollapsed' => [
 		'default' => true,
 	],
+	'wgPortableInfoboxUseFileDescriptionPage' => [
+		'default' => false,
+	],
 	'wgPortableInfoboxCacheRenderers' => [
 		'default' => true,
 	],

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1345,6 +1345,15 @@ $wgManageWikiSettings = [
 		'help' => 'Open collapsed groups when the screen is narrow.',
 		'requires' => [],
 	],
+	'wgPortableInfoboxUseFileDescriptionPage' => [
+		'name' => 'Portable Infobox Use File Description Page',
+		'from' => 'portableinfobox',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'parserfunctions',
+		'help' => 'Make embedded images link to their file description page.',
+		'requires' => [],
+	],
 	'wgShortDescriptionEnableTagline' => [
 		'name' => 'ShortDescription Enable Tagline',
 		'from' => 'shortdescription',


### PR DESCRIPTION
Following on from https://github.com/Universal-Omega/PortableInfobox/pull/122, a friend and I are hoping to use [`PortableInfobox`](https://github.com/Universal-Omega/PortableInfobox) in [a wiki](https://rainverse.wiki) we help maintain, but we want image anchor `href`s to link not to the file source, but to the File: namespaced page instead. The new config option has merged, and now I guess we need a way to change it from default. My friend wrote the patch, but GitHub prevented her creating an account so I'm helping with the PR (hence the log: "**BlankEclair** authored and **AverageHelper** committed"). I have no means of testing this code myself.

This PR should allow maintainers to set the new `PortableInfobox` config option to change where image links go, keeping the previous behavior by default.