### PR TITLE
Move StructuredDiscussions (Flow) to managewiki-restricted

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -2940,7 +2940,12 @@ $wgManageWikiExtensions = [
 		'displayname' => 'StructuredDiscussions (Flow)',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:StructuredDiscussions',
 		'conflicts' => false,
-		'requires' => [],
+		'help' => 'Deprecated by WMF, who recommends DiscussionTools instead.',
+		'requires' => [
+			'permissions' => [
+				'managewiki-restricted',
+			],
+		],
 		'install' => [
 			'sql' => [
 				'flow_revision' => "$IP/extensions/Flow/sql/mysql/tables-generated.sql"


### PR DESCRIPTION
Flow is a fairly problematic extension, and WMF is officially dropping support for it.

https://www.mediawiki.org/wiki/Structured_Discussions/Deprecation

Make the extension restricted, as we really shouldn't be moving new wikis into Flow.