### PR TITLE
T12137: NS 3000 PageImagesNamespaces on giannawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4189,12 +4189,13 @@ $wgConf->settings += [
 		'default' => [
 			NS_MAIN,
 		],
-		'gpcommonswiki' => [
-			NS_MAIN,
+		'+giannawiki' => [
+			3000
+		],
+		'+gpcommonswiki' => [
 			NS_CATEGORY,
 		],
-		'vgportdbwiki' => [
-			NS_MAIN,
+		'+vgportdbwiki' => [
 			3000,
 			3004,
 			3006,


### PR DESCRIPTION
Adds the namespace 3000 to $wgPageImagesNamespaces on gianna.miraheze.org
per T12137. Also went ahead and switched existing LS entrys to '+examplewiki'
lables to not have to repeat NS_MAIN over and over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new namespaces for `giannawiki`, `gpcommonswiki`, and `vgportdbwiki` for better content organization and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->