### PR TITLE
Exclude www.deviantart.com and jocelynsamara.deviantart.com from RottenLinks testing on rainversewiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5047,6 +5047,10 @@ $wgConf->settings += [
 			'localhost',
 			'127.0.0.1',
 		],
+		'+rainversewiki' => [
+			'jocelynsamara.deviantart.com',
+			'www.deviantart.com',
+		],
 		'+snapwikiwiki' => [
 			'smerge.imp.fu-berlin.de',
 			'www.hinkler.com.au',


### PR DESCRIPTION
A task has not been made for this, since I'm guessing I don't need to for configuration changes like these. I'm happy to make one if I have to though,

Chain of permission: [User:BlankEclair on rainversewiki has bureaucrat and sysop](https://rainverse.wiki/wiki/Special:UserRights/BlankEclair), and both that account's [user page](https://login.miraheze.org/wiki/User:BlankEclair) and its [corrosponding account on Phorge](https://issue-tracker.miraheze.org/p/BlankEclair/) lists BlankEclair on Github as her (my) account

Reason for change: Those two domains flood RottenLinks with 403s, causing it to be useless from all the noise