### PR TITLE
Bing: increase crawl-delay

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -62,4 +62,4 @@ Crawl-Delay: 2.5
 
 # Throttle BingBot
 User-agent: bingbot
-Crawl-delay: 5
+Crawl-delay: 20


### PR DESCRIPTION
Bring it in line with google & yandex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `robots.txt` to increase the crawl-delay for BingBot, potentially affecting how frequently Bing's search engine bot crawls the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->