### PR TITLE
add custom restriction levels to hypotheticalweatherwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2957,14 +2957,6 @@ $wgConf->settings += [
 				'edittemplateprotected' => true,
 			],
 		],
-		'+hypopediawiki' => [
-			'bureaucrat' => [
-				'bureaucrat' => true,
-			],
-			'extendedconfirmed' => [
-				'editextendedconfirmedprotected' => true,
-			],
-		],
 		'+igrovyesistemywiki' => [
 			'autopatrolled' => [
 				'trusted' => true,
@@ -4829,9 +4821,16 @@ $wgConf->settings += [
 			'editextendedconfirmedprotected',
 			'edittemplateprotected',
 		],
-		'+hypopediawiki' => [
-			'editbureaucratprotected',
-			'editextendedconfirmedprotected',
+		'+hypotheticalweatherwiki' => [
+			'',
+			'user',
+			'autoconfirmed',
+			'templateeditor',
+			'extendedconfirmed',
+	                'author',
+			'moderator',
+			'sysop',
+			'bureaucrat',
 		],
 		'+igrovyesistemywiki' => [
 			'trusted',
@@ -4966,9 +4965,11 @@ $wgConf->settings += [
 			'editextendedconfirmedprotected',
 			'edittemplateprotected',
 		],
-		'hypopediawiki' => [
-			'editbureaucratprotected',
-			'editextendedconfirmedprotected',
+		'hypotheticalweatherwiki' => [
+			'templateeditor',
+			'extendedconfirmed',
+			'moderator',
+			'bureaucrat',
 		],
 		'infopediawiki' => [
 			'editextendedconfirmedprotected',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4827,7 +4827,7 @@ $wgConf->settings += [
 			'autoconfirmed',
 			'templateeditor',
 			'extendedconfirmed',
-	                'author',
+			'author',
 			'moderator',
 			'sysop',
 			'bureaucrat',


### PR DESCRIPTION
Also, this removes the long-gone `hypopediawiki` from the config and replaces it with `hypotheticalweatherwiki` that is now present. If there are any problems with this request please let me know. Thanks!