### PR TITLE
Chore: Remove old wiki projects from the source code

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1582,40 +1582,6 @@ $wgConf->settings += [
 				],
 			],
 		],
-		'hsckwiki' => [
-			'poweredby' => [
-				'songnguxyz' => [
-					'src' => 'https://static.miraheze.org/lhmnwiki/5/58/Footer.SN.xyz.svg',
-					'url' => 'https://songngu.xyz',
-					'alt' => 'Dự án được bảo quản bởi SongNgư.xyz',
-					"height" => "32",
-				        "width" => "200"
-				],
-				'miraheze' => [
-					'src' => 'https://static.miraheze.org/lhmnwiki/1/1c/Miraheze.svg',
-					'url' => 'https://meta.miraheze.org/wiki/Special:MyLanguage/Miraheze',
-					'alt' => 'Lưu trữ bởi Miraheze',
-					"height" => "60",
-				        "width" => "60"
-				],
-				'mediawiki' => [
-					'src' => 'https://static.miraheze.org/lhmnwiki/9/9b/MediaWiki.svg',
-					'url' => 'https://www.mediawiki.org',
-					'alt' => 'Xây dựng trên MediaWiki',
-					'height' => "60",
-					'width' => "185",
-				],
-			],
-			'copyright' => [
-				'copyright' => [
-					'src' => 'https://static.miraheze.org/lhmnwiki/4/4e/CC-BY-SA-4.svg',
-					'url' => 'https://creativecommons.org/licenses/by-sa/4.0/',
-					'alt' => 'Creative Commons Ghi công - Chia sẻ tương tự 4.0 (CC BY-SA 4.0)',
-					'height' => "50",
-					'width' => "150",
-				],
-			],
-		],
 		'lhmnwiki' => [
 			'poweredby' => [
 				'songnguxyz' => [
@@ -6299,29 +6265,11 @@ $wgConf->settings += [
 				'sister' => false,
 			],
 		],
-		'snxyzincubatorwiki' => [
-			'k' => [
-				'name' => 'Cookie Run: Kingdom Wiki',
-				'dbsuffix' => 'crk',
-				'wikitag' => 'cookierunkingdom',
-				'sister' => false,
-			],
-			'c' => [
-				'name' => 'Cookie Run Wiki',
-				'dbsuffix' => 'cr',
-				'wikitag' => 'cookierun',
-				'sister' => false,
-			],
-		],
 	],
 	'wmincProjectSite' => [
 		'default' => [
 			'name' => 'Incubator Plus 2.0',
 			'short' => 'incplus',
-		],
-		'snxyzincubatorwiki' => [
-			'name' => 'Pisces\'s Incubator',
-			'short' => 'pi',
 		],
 	],
 	'wmincExistingWikis' => [

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -510,40 +510,6 @@ switch ( $wi->dbname ) {
 		}
 
 		break;
-	case 'snxyzincubatorwiki':
-		$wgLogos = [
-			'1x' => "https://static.wikitide.net/snxyzincubatorwiki/2/2e/Incubator_Logo.2023.svg",
-			'svg' => "https://static.wikitide.net/snxyzincubatorwiki/2/2e/Incubator_Logo.2023.svg",
-			'icon' => "https://static.wikitide.net/snxyzincubatorwiki/2/2e/Incubator_Logo.2023.svg",
-			'wordmark' => [
-				'src' => "https://static.wikitide.net/snxyzincubatorwiki/d/d5/Wordmark_EN.svg",
-				'1x' => "https://static.wikitide.net/snxyzincubatorwiki/d/d5/Wordmark_EN.svg",
-				'width' => 135,
-				'height' => 20,
-			],
-			'tagline' => [
-				'src' => "https://static.wikitide.net/snxyzincubatorwiki/6/60/Tagline_EN.svg",
-				'width' => 135,
-				'height' => 15,
-			],
-			'variants' => [
-				'vi' => [
-					'wordmark' => [
-						'src' => "https://static.wikitide.net/snxyzincubatorwiki/4/41/Wordmark_VI.svg",
-						'1x' => "https://static.wikitide.net/snxyzincubatorwiki/4/41/Wordmark_VI.svg",
-						'width' => 135,
-						'height' => 20,
-					],
-					'tagline' => [
-						'src' => "https://static.wikitide.net/snxyzincubatorwiki/1/1b/Tagline_VI.svg",
-						'width' => 135,
-						'height' => 15,
-					],
-				],
-			],
-		];
-
-		break;
 	case 'spacewiki':
 		$wgExtraNamespaces += [
 			NS_TALK => 'talk',


### PR DESCRIPTION
Affected wikis:
* `hsckwiki`
* `snxyzincubator`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed outdated configurations for 'hsckwiki' and 'snxyzincubatorwiki'.
  - Deleted logo settings for 'snxyzincubatorwiki'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->