### PR TITLE
T12195: Enable $wgCirrusSearchPrefixSearchStartsWithAnyWord on rainversewiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -565,6 +565,12 @@ $wgConf->settings += [
 		],
 	],
 
+	// CirrusSearch
+	'wgCirrusSearchPrefixSearchStartsWithAnyWord' => [
+		'default' => false,
+		'rainversewiki' => true,
+	],
+
 	// Citizen
 	'wgCitizenThemeDefault' => [
 		'default' => 'auto',


### PR DESCRIPTION
After this is merged, someone will need to do an in-place reindex of the database to unbreak prefix searching (per [$wgCirrusSearchPrefixSearchStartsWithAnyWord documentation](https://gerrit.wikimedia.org/g/mediawiki/extensions/CirrusSearch/+/fb3853fd0439aa1f0763fabd21c921d3c538c763/docs/settings.txt#464)). CirrusSearch's README has [examples](https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/CirrusSearch/+/fb3853fd0439aa1f0763fabd21c921d3c538c763/README#153).