### PR TITLE
$wgRSSAllowLinkTag: Escape HTML

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -212,7 +212,7 @@ $wgManageWikiSettings = [
 		'type' => 'check',
 		'overridedefault' => false,
 		'section' => 'other',
-		'help' => 'If enabled, links (<a> tags) will be shown. If disabled, the tags are escaped.',
+		'help' => 'If enabled, links (&lt;a&gt; tags) will be shown. If disabled, the tags are escaped.',
 		'requires' => [
 			'extensions' => [
 				'rss',


### PR DESCRIPTION
Here's how it looks like right now:
![](https://github.com/user-attachments/assets/dc9819ba-caf0-4204-b0f5-6f064f717c9e)
