### PR TITLE
add short-title to metawikibeta's FeaturedFeeds

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -431,6 +431,7 @@ switch ( $wi->dbname ) {
 		$wgFeaturedFeeds['test'] = [
 			'page' => 'feedtest',
 			'title' => 'feedtest-title',
+			'short-title' => 'feedtest-short-title',
 			'description' => 'feedtest-description',
 			'entryName' => 'feedtest-entryname',
 		];


### PR DESCRIPTION
turns out configuring short-title is also needed, otherwise FeaturedFeeds will call wfMessage(NULL)