### PR TITLE
T12447: Add GoogleForms

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1418,11 +1418,11 @@ $wgManageWikiExtensions = [
 		'section' => 'specialpages',
 	],
 	'googleforms' => [
-		'name' => 'CustomSearchProfiles',
+		'name' => 'GoogleForms',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:GoogleForms',
 		'conflicts' => false,
 		'requires' => [],
-		'section' => 'other',
+		'section' => 'parserhooks',
 	],
 	'googlenewssitemap' => [
 		'name' => 'GoogleNewsSitemap',

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1417,6 +1417,13 @@ $wgManageWikiExtensions = [
 		],
 		'section' => 'specialpages',
 	],
+	'googleforms' => [
+		'name' => 'CustomSearchProfiles',
+		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:GoogleForms',
+		'conflicts' => false,
+		'requires' => [],
+		'section' => 'other',
+	],
 	'googlenewssitemap' => [
 		'name' => 'GoogleNewsSitemap',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:GoogleNewsSitemap',


### PR DESCRIPTION
If I understand right, this and https://github.com/miraheze/mediawiki-repos/pull/30 together should add the GoogleForms extension to `Special:ManageWiki/extensions`.