### PR TITLE
Remove spacewiki code in LocalWiki.php

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -537,23 +537,6 @@ switch ( $wi->dbname ) {
 		}
 
 		break;
-	case 'spacewiki':
-		$wgExtraNamespaces += [
-			NS_TALK => 'talk',
-			NS_USER => 'user',
-			NS_USER_TALK => 'user-talk',
-			NS_FILE => 'file',
-			NS_FILE_TALK => 'file-talk',
-			NS_MEDIAWIKI => 'mediawiki',
-			NS_MEDIAWIKI_TALK => 'mediawiki-talk',
-			NS_TEMPLATE => 'template',
-			NS_TEMPLATE_TALK => 'template-talk',
-			NS_HELP => 'guide',
-			NS_HELP_TALK => 'guide-talk',
-			NS_CATEGORY => 'category',
-			NS_CATEGORY_TALK => 'category-talk'
-		];
-		break;
 	case 'srewiki':
 		wfLoadExtension( 'LdapAuthentication' );
 


### PR DESCRIPTION
I requested this a code be added in #5541, but the code never actually worked (it only worked on my test wiki), and now all of spacewiki is being rewritten, so the code isn't needed anymore.

It doesn't actually affect the wiki if the code isn't removed, so you can close and ignore this if you find it unnecessary.