### PR TITLE
Reenable Evelution for MediaWiki 1.42

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6709,7 +6709,6 @@ $wi::$disabledExtensions = [
 
 if ( $wi->version >= '1.42' ) {
 	array_push( $wi::$disabledExtensions, 'chameleon' );
-	array_push( $wi::$disabledExtensions, 'evelution' );
 	array_push( $wi::$disabledExtensions, 'eveskin' );
 	array_push( $wi::$disabledExtensions, 'femiwiki' );
 	array_push( $wi::$disabledExtensions, 'rightfunctions' );


### PR DESCRIPTION
Evelution now supports MediaWiki 1.42 in version [156.0.0](https://github.com/AWikia/SkinEvelution/releases/tag/156.0.0) and above. I have also tested locally, and it doesn't fail immediately (the missing icons are due to my browser):
![](https://github.com/user-attachments/assets/3d235b42-a239-4a50-8cdd-7dceff70235f)
