### PR TITLE
Update UploadWizard settings for kagagawiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -213,6 +213,22 @@ switch ( $wi->dbname ) {
 				'en' => 'English',
 			],
 			'licenses' => [
+				'cc-by-sa-4.0' => [
+					'msg' => 'mwe-upwiz-license-cc-by-sa-4.0-text',
+					'msgExplain' => 'mwe-upwiz-source-ownwork-cc-by-sa-4.0-explain',
+					'icons' => [ 'cc-by', 'cc-sa' ],
+					'url' => '//creativecommons.org/licenses/by-sa/4.0/',
+					'languageCodePrefix' => 'deed.',
+					'availableLanguages' => $uwCcAvailableLanguages
+				],
+				'cc-zero' => [
+					'msg' => 'mwe-upwiz-license-cc-zero-text',
+					'msgExplain' => 'mwe-upwiz-source-ownwork-cc-zero-explain',
+					'icons' => [ 'cc-zero' ],
+					'url' => '//creativecommons.org/publicdomain/zero/1.0/',
+					'languageCodePrefix' => 'deed.',
+					'availableLanguages' => $uwCcAvailableLanguages
+				],
 				'rs-inc' => [
 					'msg' => 'mwe-upwiz-license-rs-inc-text',
 					'msgExplain' => 'mwe-upwiz-license-rs-inc-explain',
@@ -255,6 +271,7 @@ switch ( $wi->dbname ) {
 					],
 				],
 			],
+			'templateOptions' => [],
 		];
 		break;
 	case 'ldapwikiwiki':

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -201,30 +201,27 @@ switch ( $wi->dbname ) {
 		$wgUploadWizardConfig = [
 			'campaignExpensiveStatsEnabled' => false,
 			'flickrApiKey' => $wmgUploadWizardFlickrApiKey,
+			'debug' => false,
+			'altUploadForm' => 'Special:Upload',
+			'feedbackLink' => false,
+			'alternativeUploadToolsPage' => false,
+			'enableFormData' => true,
+			'enableMultipleFiles' => true,
+			'enableMultiFileSelect' => true,
 			'uwLanguages' => [
 				'ja' => '日本語',
 				'en' => 'English',
 			],
 			'licenses' => [
-				'cc-by-sa-4.0' => [
-					'msg' => 'mwe-upwiz-license-cc-by-sa-4.0-text',
-					'icons' => [ 'cc-by', 'cc-sa' ],
-					'url' => '//creativecommons.org/licenses/by-sa/4.0/',
-					'languageCodePrefix' => 'deed.',
-				],
-				'cc-zero' => [
-					'msg' => 'mwe-upwiz-license-cc-zero-text',
-					'icons' => [ 'cc-zero' ],
-					'url' => '//creativecommons.org/publicdomain/zero/1.0/',
-					'languageCodePrefix' => 'deed.',
-				],
 				'rs-inc' => [
 					'msg' => 'mwe-upwiz-license-rs-inc-text',
+					'msgExplain' => 'mwe-upwiz-license-rs-inc-explain',
 					'templates' => [ 'rs-inc' ],
 					'url' => '//rightsstatements.org/page/InC/1.0/',
 				],
 				'rs-und' => [
 					'msg' => 'mwe-upwiz-license-rs-und-text',
+					'msgExplain' => 'mwe-upwiz-license-rs-und-explain',
 					'templates' => [ 'rs-und' ],
 					'url' => '//rightsstatements.org/page/UND/1.0/',
 				],

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -207,24 +207,24 @@ switch ( $wi->dbname ) {
 			],
 			'licenses' => [
 				'cc-by-sa-4.0' => [
-					'msg' => 'mwe-upwiz-license-cc-by-sa-4.0',
+					'msg' => 'mwe-upwiz-license-cc-by-sa-4.0-text',
 					'icons' => [ 'cc-by', 'cc-sa' ],
 					'url' => '//creativecommons.org/licenses/by-sa/4.0/',
 					'languageCodePrefix' => 'deed.',
 				],
 				'cc-zero' => [
-					'msg' => 'mwe-upwiz-license-cc-zero',
+					'msg' => 'mwe-upwiz-license-cc-zero-text',
 					'icons' => [ 'cc-zero' ],
 					'url' => '//creativecommons.org/publicdomain/zero/1.0/',
 					'languageCodePrefix' => 'deed.',
 				],
 				'rs-inc' => [
-					'msg' => 'mwe-upwiz-license-rs-inc',
+					'msg' => 'mwe-upwiz-license-rs-inc-text',
 					'templates' => [ 'rs-inc' ],
 					'url' => '//rightsstatements.org/page/InC/1.0/',
 				],
 				'rs-und' => [
-					'msg' => 'mwe-upwiz-license-rs-und',
+					'msg' => 'mwe-upwiz-license-rs-und-text',
 					'templates' => [ 'rs-und' ],
 					'url' => '//rightsstatements.org/page/UND/1.0/',
 				],

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -198,6 +198,13 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'kagagawiki':
+		$uwCcAvailableLanguages = [
+			'an', 'ar', 'az', 'be', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el',
+			'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'fy', 'ga',
+			'gl', 'hi', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ko', 'lt',
+			'lv', 'ms', 'nl', 'no', 'pl', 'pt', 'pt-br', 'ro', 'ru', 'sk',
+			'sl', 'sr-latn', 'sv', 'tr', 'uk', 'zh-hans', 'zh-hant'
+		];
 		$wgUploadWizardConfig = [
 			'campaignExpensiveStatsEnabled' => false,
 			'flickrApiKey' => $wmgUploadWizardFlickrApiKey,


### PR DESCRIPTION
We have some problems on UploadWizard.

### 1. Complex choices
We want to use more simple choices.

We are expecting to these choices.
![スクリーンショット 2024-08-22 16 47 41](https://github.com/user-attachments/assets/edac463c-562a-4cb0-adc4-f5327ba680a9)
![スクリーンショット 2024-08-22 16 47 50](https://github.com/user-attachments/assets/e63a9601-af60-4d6b-ae61-b3fce6437d91)
These are our old version wiki before transporting in Miraheze.

So, we want to disable some choices if we can.
![スクリーンショット 2024-08-22 16 43 04](https://github.com/user-attachments/assets/32e86d5c-018e-41e0-8085-9a22f2b971cb)
![スクリーンショット 2024-08-22 16 44 37](https://github.com/user-attachments/assets/d321afab-5f13-4370-9ed1-bcb2fe90076e)

### 2. System messages are not working.

I created some message pages like below, but these seems to be not working.
- https://kagaga.jp/wiki/MediaWiki:Wm-license-cc-free
- https://kagaga.jp/wiki/MediaWiki:Wm-license-cc-free-to-share-header
- https://kagaga.jp/wiki/MediaWiki:Wm-license-cc-free-to-share-text
I know this is template error, but I couldn't find any solutions so please let me know them.
This template was imported from Wikipedia and not any changes.

https://kagaga.jp/wiki/テンプレート:Cc-by-sa-4.0
![スクリーンショット 2024-08-22 16 40 45](https://github.com/user-attachments/assets/f8bc0b80-5d04-492e-a05b-2c675d2e8d1d)





