### PR TITLE
Add edittemplateprotected to $wgAvailableRights on cricketnepalwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5088,6 +5088,9 @@ $wgConf->settings += [
 		'collegecitoyenwiki' => [
 			'editextendedsemiprotected',
 		],
+		'cricketnepalwiki' => [
+			'edittemplateprotected',
+		],
 		'csydeswiki' => [
 			'editblacklisted',
 		],


### PR DESCRIPTION
Turns out that you can't give the edittemplateprotected right using ManageWiki, I'm hoping that adding it to $wgAvailableRights will make it automatically pop up on there.