### PR TITLE
T12565: Fully disable transcodes for hommwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -192,6 +192,11 @@ switch ( $wi->dbname ) {
 		];
 
 		break;
+	case 'hommwiki':
+		$wgEnabledAudioTranscodeSet = [];
+		$wgEnabledTranscodeSet = [];
+
+		break;
 	case 'houkai2ndwiki':
 		$wgSpecialPages['Analytics'] = DisabledSpecialPage::getCallback( 'Analytics', 'MatomoAnalytics-disabled' );
 		$wgPageImagesScores['position'] = [ 100, -100, -100, -100 ];

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -194,7 +194,6 @@ switch ( $wi->dbname ) {
 		break;
 	case 'hommwiki':
 		$wgEnabledAudioTranscodeSet = [];
-		$wgEnabledTranscodeSet = [];
 
 		break;
 	case 'houkai2ndwiki':


### PR DESCRIPTION
$wgEnableTranscode should, in theory, disable transcoding. However, there is (probably) a bug upstream that makes it not fully honor that setting. For now, we'll just do a workaround to make the extension chill out, and perhaps revert this commit once the extension is fixed.

Miraheze issue tracker task: https://issue-tracker.miraheze.org/T12565
Relevant upstream task: https://phabricator.wikimedia.org/T374433