### PR TITLE
Add editbureaucratprotected to cricketnepalwiki and $wgAvailableRights

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4961,8 +4961,8 @@ $wgConf->settings += [
 			'editextendedsemiprotected',
 		],
 		'+cricketnepalwiki' => [
+			'editbureaucratprotected',
 			'edittemplateprotected',
-	                'editbureaucratprotected',
 		],
 		'+csydeswiki' => [
 			'editblacklisted',
@@ -5115,8 +5115,8 @@ $wgConf->settings += [
 			'editextendedsemiprotected',
 		],
 		'cricketnepalwiki' => [
+			'editbureaucratprotected',
 			'edittemplateprotected',
-	                'editbureaucratprotected',
 		],
 		'csydeswiki' => [
 			'editblacklisted',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4962,6 +4962,7 @@ $wgConf->settings += [
 		],
 		'+cricketnepalwiki' => [
 			'edittemplateprotected',
+	                'editbureaucratprotected',
 		],
 		'+csydeswiki' => [
 			'editblacklisted',
@@ -5115,6 +5116,7 @@ $wgConf->settings += [
 		],
 		'cricketnepalwiki' => [
 			'edittemplateprotected',
+	                'editbureaucratprotected',
 		],
 		'csydeswiki' => [
 			'editblacklisted',


### PR DESCRIPTION
Adding new protection level and Turns out that you can't give the editbureaucratprotected right using ManageWiki, I'm hoping that adding it to $wgAvailableRights will make it automatically pop up on there.