### PR TITLE
Allow *.{miraheze,wikitide}.org and the custom domain for TemplateStyles

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5560,16 +5560,22 @@ $wgConf->settings += [
 				'<^(?:https:)?//upload\\.wikimedia\\.org/wikipedia/commons/>',
 				'<^(?:https:)?//static\\.miraheze\\.org/>',
 				'<^(?:https:)?//static\\.wikitide\\.net/>',
+				'<^(?:https:)?//[a-zA-Z0-9\\-]\\.(miraheze|wikitide)\\.org/w/img_auth\\.php/>',
+				'<^(?:https:)?//' . preg_quote( $wi->server ) . '/w/img_auth\\.php/>',
 			],
 			'image' => [
 				'<^(?:https:)?//upload\\.wikimedia\\.org/wikipedia/commons/>',
 				'<^(?:https:)?//static\\.miraheze\\.org/>',
 				'<^(?:https:)?//static\\.wikitide\\.net/>',
+				'<^(?:https:)?//[a-zA-Z0-9\\-]\\.(miraheze|wikitide)\\.org/w/img_auth\\.php/>',
+				'<^(?:https:)?//' . preg_quote( $wi->server ) . '/w/img_auth\\.php/>',
 			],
 			'svg' => [
 				'<^(?:https:)?//upload\\.wikimedia\\.org/wikipedia/commons/[^?#]*\\.svg(?:[?#]|$)>',
 				'<^(?:https:)?//static\\.miraheze\\.org/[^?#]*\\.svg(?:[?#]|$)>',
 				'<^(?:https:)?//static\\.wikitide\\.net/[^?#]*\\.svg(?:[?#]|$)>',
+				'<^(?:https:)?//[a-zA-Z0-9\\-]\\.(miraheze|wikitide)\\.org/w/img_auth\\.php/[^?#]*\\.svg(?:[?#]|$)>',
+				'<^(?:https:)?//' . preg_quote( $wi->server ) . '/w/img_auth\\.php/[^?#]*\\.svg(?:[?#]|$)>',
 			],
 			'font' => [],
 			'namespace' => [


### PR DESCRIPTION
Currently, /w/img_auth.php URLs cannot be used for TemplateStyles, which is problematic for private wikis (example: #general in Discord/#miraheze-offtopic on IRC, at 2024-09-17 10:17:35 UTC).

We allow `[a-zA-Z0-9\-]\.(miraheze|wikitide)\.org/w/img_auth.php` for Miraheze controlled domains, and `{$wi->server}/w/img_auth.php` for custom domains. In the event that the wiki is not a custom domain, it will fallback to the Miraheze domain and would effectively be a no-op.