### PR TITLE
Add editconsulprotected to cricketnepalwiki and $wgAvailableRights

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4966,7 +4966,7 @@ $wgConf->settings += [
 		],
 		'+cricketnepalwiki' => [
 			'editbureaucratprotected',
-	                'editconsulprotected',
+			'editconsulprotected',
 			'edittemplateprotected',
 		],
 		'+csydeswiki' => [
@@ -5121,7 +5121,7 @@ $wgConf->settings += [
 		],
 		'cricketnepalwiki' => [
 			'editbureaucratprotected',
-	                'editconsulprotected',
+			'editconsulprotected',
 			'edittemplateprotected',
 		],
 		'csydeswiki' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4966,6 +4966,7 @@ $wgConf->settings += [
 		],
 		'+cricketnepalwiki' => [
 			'editbureaucratprotected',
+	                'editconsulprotected',
 			'edittemplateprotected',
 		],
 		'+csydeswiki' => [
@@ -5120,6 +5121,7 @@ $wgConf->settings += [
 		],
 		'cricketnepalwiki' => [
 			'editbureaucratprotected',
+	                'editconsulprotected',
 			'edittemplateprotected',
 		],
 		'csydeswiki' => [


### PR DESCRIPTION
Adding new protection level and Turns out that you can't give the editconsulprotected right using ManageWiki, I'm hoping that adding it to $wgAvailableRights will make it automatically pop up on there.