### PR TITLE
Fix "wgCargoAllowedSQLFunctions" being undefined

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -376,7 +376,7 @@ $wgConf->settings += [
 	],
 
 	// Cargo
-	'+wgCargoAllowedSQLFunctions' => [
+	'wgCargoAllowedSQLFunctions' => [
 		'default' => [],
 		'rainversewiki' => [
 			'NATURAL_SORT_KEY',


### PR DESCRIPTION
On wikis that don't have cargo enabled, it would throw a "wgCargoAllowedSQLFunctions" is undefined warning.