### PR TITLE
Set $wgCargoAllowedSQLFunctions in LocalWiki.php

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -376,12 +376,6 @@ $wgConf->settings += [
 	],
 
 	// Cargo
-	'wgCargoAllowedSQLFunctions' => [
-		'default' => [],
-		'rainversewiki' => [
-			'NATURAL_SORT_KEY',
-		],
-	],
 	'wgCargoDBuser' => [
 		'default' => 'cargouser',
 	],

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -597,6 +597,8 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'rainversewiki':
+		$wgCargoAllowedSQLFunctions[] = 'NATURAL_SORT_KEY';
+
 		$wgJsonConfigs['Tabular.JsonConfig']['remote'] = [
 			'url' => 'https://commons.wikimedia.org/w/api.php'
 		];


### PR DESCRIPTION
It would be an empty array otherwise, which makes every function unusable