### PR TITLE
Re-enable Tweeki skin

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6765,7 +6765,7 @@ $wi::$disabledExtensions = [
 	'evelution' => 'Incompatible with MediaWiki 1.42',
 	'eveskin' => 'Incompatible with MediaWiki 1.42',
 	'femiwiki' => 'Incompatible with MediaWiki 1.42',
-	'snapwikiskin' => 'Incompatible with MediaWiki 1.42'
+	'snapwikiskin' => 'Incompatible with MediaWiki 1.42',
 ];
 
 $globals = MirahezeFunctions::getConfigGlobals();

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6773,7 +6773,6 @@ if ( $wi->version >= '1.42' ) {
 	array_push( $wi::$disabledExtensions, 'eveskin' );
 	array_push( $wi::$disabledExtensions, 'femiwiki' );
 	array_push( $wi::$disabledExtensions, 'snapwikiskin' );
-	array_push( $wi::$disabledExtensions, 'tweeki' );
 }
 
 $globals = MirahezeFunctions::getConfigGlobals();


### PR DESCRIPTION
Confirmed to be compatible with 1.42 since stable 4.39.1
More info: https://tweeki.kollabor.at/wiki/Installation#Compatibility