### PR TITLE
CodeMirror configuaration for abyssalwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4664,6 +4664,9 @@ $wgConf->settings += [
 			'usebetatoolbar' => 1,
 			'usebetatoolbar-cgd' => 1,
 		],
+		'+abyssalwiki' => [
+			'usecodemirror' => 1,
+		],
 		'+crashspyrowiki' => [
 			'rcenhancedfilters-disable' => 1,
 			'wlenhancedfilters-disable' => 1,


### PR DESCRIPTION
Have CodeMirror be activated by default on Abyssal Wiki