### PR TITLE
lhmnwiki: Check for active extension before calling EC.php

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -404,7 +404,9 @@ switch ( $wi->dbname ) {
 		];
 
 		// SocialProfile/UserStats configurations
-		require_once "$IP/extensions/SocialProfile/UserStats/EditCount.php";
+		if ( $wi->isExtensionActive( 'SocialProfile' ) ) {
+			require_once "$IP/extensions/SocialProfile/UserStats/EditCount.php";
+		
 			// User level definitions
 			$wgUserLevels = [
 				'Lớp lá' => 0,
@@ -424,7 +426,7 @@ switch ( $wi->dbname ) {
 				'Đại học' => 800000,
 				'Cao học' => 1000000
 			];
-
+		}
 		break;
 	case 'libertygamewiki':
 		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';


### PR DESCRIPTION
Per T12767: Added a check to see if the `SocialProfile` extension is active before requiring the `EditCount.php` file.