### PR TITLE
Fix class used for TitleKey in wgSearchType

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5411,7 +5411,7 @@ $wgConf->settings += [
 	// Search
 	'wgSearchType' => [
 		'ext-CirrusSearch' => 'CirrusSearch',
-		'ext-TitleKey' => MediaWiki\Extension\TitleKey\SearchEngine::class,
+		'ext-TitleKey' => MediaWiki\Extension\TitleKey\SearchEngineMySQL::class,
 	],
 
 	// SecurePoll


### PR DESCRIPTION
This was changed in https://github.com/wikimedia/mediawiki-extensions-TitleKey/commit/a37af77932c71fb32311f73f99a19ba23f18cacc#diff-6a6295f752062fb0eec4a9df4e87c164b8d8d3b48023a54a1e682671296eb8a3R56