### PR TITLE
Open interwiki links in new tab

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2861,6 +2861,9 @@ $wgConf->settings += [
 			[ 'newtablinks', 'wikiwalk' ],
 			'_self' => [ 'sametablinks' ]
 		],
+		'randrwiki' => [
+			'_blank' => [ '' ]
+		],
 		'scruffwiki' => [
 			'_blank' => [ '' ]
 		],


### PR DESCRIPTION
Get interwiki links to open in a new tab for the Popular Music Studies Wiki.