### PR TITLE
Remove $mcpMessageCachePerformanceMsgPrefixes

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -799,30 +799,6 @@ $wgULSNoImeSelectors[] = '.ace_editor textarea';
 
 $wgMaxMsgCacheEntrySize = 1024;
 
-$mcpMessageCachePerformanceMsgPrefixes = [
-	'specialpages-specialpagegroup-',
-	'apioutput-view-',
-	'fallback-view-',
-	'anisa-action-',
-	'anisa-view-',
-	'bluesky-action-',
-	'bluesky-view-',
-	'citizen-action-',
-	'citizen-view-',
-	'cologneblue-action-',
-	'cologneblue-view-',
-	'metrolook-action-',
-	'metrolook-view-',
-	'timeless-action-',
-	'timeless-view-',
-	'vector-action-',
-	'vector-view-',
-	'conversion-ns',
-	'tooltip-',
-	'accesskey-',
-	'nstab-'
-];
-
 $wgPoolCounterConf = [
 	'ArticleView' => [
 		'class' => 'PoolCounter_Client',


### PR DESCRIPTION
We don't use the MessageCachePerformance extension anymore