### PR TITLE
Unset wgObjectCacheSessionExpiry

### DIFF
--- a/GlobalCache.php
+++ b/GlobalCache.php
@@ -139,9 +139,6 @@ $wgDiscussionToolsTalkPageParserCacheExpiry = 86400 * 10;
 // 3 days
 $wgRevisionCacheExpiry = 86400 * 3;
 
-// 1 day
-$wgObjectCacheSessionExpiry = 86400;
-
 // 7 days
 $wgDLPMaxCacheTime = 604800;
 


### PR DESCRIPTION
Not sure if us setting this to 1 day without using kask etc is causing us issues. Lets just unset this for now.