### PR TITLE
Set LoadMonitor

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -96,10 +96,13 @@ if ( strpos( wfHostname(), 'test' ) === 0 ) {
 	];
 }
 
+$wgLBFactoryConf['loadMonitor']['class'] = '\Wikimedia\Rdbms\LoadMonitor';
 // Disable LoadMonitor in CLI, it doesn't provide much value in CLI.
 if ( PHP_SAPI === 'cli' ) {
-	$wgLBFactoryConf['loadMonitorClass'] = \Wikimedia\Rdbms\LoadMonitorNull::class;
+	$wgLBFactoryConf['loadMonitor']['class'] = '\Wikimedia\Rdbms\LoadMonitorNull';
 }
+
+$wgLBFactoryConf['loadMonitor']['maxConnCount'] = 350;
 
 // Disallow web request database transactions that are slower than 10 seconds
 $wgMaxUserDBWriteDuration = 10;

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -697,13 +697,13 @@ switch ( $wi->dbname ) {
 
 		break;
 	case 'testwikibeta':
-		$wgUserLevels = array(
+		$wgUserLevels = [
 			'Recruit' => 0,
 			'Apprentice' => 1200,
 			'Private' => 1750,
 			'Corporal' => 2500,
 			'Sergeant' => 5000,
-			'Gunnery Sergeant' =>10000,
+			'Gunnery Sergeant' => 10000,
 			'Lieutenant' => 20000,
 			'Captain' => 35000,
 			'Major' => 50000,
@@ -716,7 +716,7 @@ switch ( $wi->dbname ) {
 			'Lieutenant General' => 650000,
 			'General' => 800000,
 			'General of the Army' => 1000000,
-		);
+		];
 		break;
 	case 'tuscriaturaswiki':
 		$wgHooks['AfterFinalPageOutput'][] = 'onAfterFinalPageOutput';

--- a/rpc/RunJobs.php
+++ b/rpc/RunJobs.php
@@ -24,7 +24,7 @@
 
 use MediaWiki\MediaWikiServices;
 
-if ( !in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '0:0:0:0:0:0:0:1', '::1' ), true ) ) {
+if ( !in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '0:0:0:0:0:0:0:1', '::1' ], true ) ) {
 	http_response_code( 500 );
 	die( "Only loopback requests are allowed.\n" );
 } elseif ( $_SERVER['REQUEST_METHOD'] !== 'POST' ) {


### PR DESCRIPTION
It appears that this is the default here https://github.com/wikimedia/mediawiki/blob/4bd27f449569c211f6e74fa48e4e6ed6506d4a27/includes/libs/rdbms/lbfactory/LBFactoryMulti.php#L159

But we want to set maxConnCount I think, as some times we have an issue where a db server goes down it gets overloaded when it is back online. It's basically the same fix as https://phabricator.wikimedia.org/T360930