### PR TITLE
Fix ownWorkDefault for lhmnwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -364,7 +364,7 @@ switch ( $wi->dbname ) {
 			],
 			'licensing' => [
 				'defaultType' => 'thirdParty',
-				'ownWorkDefault' => 'choices',
+				'ownWorkDefault' => 'choice',
 				'ownWork' => [
 					'type' => 'or',
 					'template' => 'self',


### PR DESCRIPTION
It can only be three types: https://github.com/wikimedia/mediawiki-extensions-UploadWizard/blob/a3a6ee9120ac506a1701f4d9d32667b08eaca2a4/includes/Specials/SpecialUploadWizard.php#L228

Bug: T12965