### PR TITLE
Remove 2880 as a candidate MultimediaViewer thumbnail size for Strinova Wiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4333,6 +4333,25 @@ $wgConf->settings += [
 	'wgMediaViewerEnableByDefault' => [
 		'default' => true,
 	],
+	'wgMediaViewerThumbnailBucketSizes' => [
+		'default' => [
+			320,
+			800,
+			1024,
+			1280,
+			1920,
+			2560,
+			2880,
+		],
+		'strinovawiki' => [
+			320,
+			800,
+			1024,
+			1280,
+			1920,
+			2560,
+		],
+	],
 
 	// Math
 	'wgMathValidModes' => [


### PR DESCRIPTION
Address T12977. Not sure if the issue will be completely fixed, but this config seems to be the culprit. 