### PR TITLE
Fix bast161 and bast181 ipv6 in wgCdnServersNoPurge

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6169,9 +6169,9 @@ $wgConf->settings += [
 	'wgCdnServersNoPurge' => [
 		'default' => [
 			// bast161
-			'[2602:294:0:b13::101]',
+			'2602:294:0:b13::101',
 			// bast181
-			'[2602:294:0:b12::102]',
+			'2602:294:0:b12::102',
 			// localhost is a must!
 			'127.0.0.1',
 			// CloudFlare IPs - https://www.cloudflare.com/ips/


### PR DESCRIPTION
It can't be put in [].