### PR TITLE
Configure custom contact forms for lhmnwiki

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -315,8 +315,8 @@ switch ( $wi->dbname ) {
 		];
 
 		break;
-	case 'lhmnwiki':
-		// UploadWizard configurations
+	case 'lhmnwiki': // thiết lập Wiki Lớp Học Mật Ngữ (lophocmatngu.wiki)
+		// UploadWizard
 		$wgUploadWizardConfig = [
 			'tutorial' => [
 				'skip' => false,
@@ -408,11 +408,11 @@ switch ( $wi->dbname ) {
 			]
 		];
 
-		// SocialProfile/UserStats configurations
+		// SocialProfile/UserStats
 		if ( $wi->isExtensionActive( 'SocialProfile' ) ) {
 			require_once "$IP/extensions/SocialProfile/UserStats/EditCount.php";
 
-			// User level definitions
+			// Định nghĩa cấp độ
 			$wgUserLevels = [
 				'Lớp lá' => 0,
 				'Mầm non' => 1200,
@@ -432,6 +432,131 @@ switch ( $wi->dbname ) {
 				'Cao học' => 1000000
 			];
 		}
+		
+		// ContactForm
+		$wgContactConfig['default'] = [ // Biểu mẫu mặc định
+			'RecipientEmail' => 'hotro@lophocmatngu.wiki',
+			'SenderName' => 'Liên hệ từ WLHMN',
+			'RequireDetails' => true,
+			'NameReadonly' => false,
+			'EmailReadonly' => false,
+			'SubjectReadonly' => false,
+			'UseCustomBlockMessage' => false,
+			'Redirect' => null,
+			'RLModules' => [],
+			'RLStyleModules' => [],
+			'AdditionalFields' => [
+				'Text' => [
+					'label-message' => 'emailmessage',
+					'type' => 'textarea',
+					'required' => true
+					]
+				],
+			'FieldsMergeStrategy' => null
+		];
+
+		$wgContactConfig['banquyen'] = [ // Biểu mẫu yêu cầu gỡ bỏ
+			'RecipientEmail' => 'banquyen@lophocmatngu.wiki',
+			'SenderName' => 'Xử lý bản quyền WLHMN',
+			'RequireDetails' => true,
+			'NameReadonly' => false,
+			'EmailReadonly' => false,
+			'SubjectReadonly' => true,
+			'UseCustomBlockMessage' => false,
+			'Redirect' => null,
+			'RLModules' => [], // Resource loader modules to add to the form display page.
+			'RLStyleModules' => [], // Resource loader CSS modules to add to the form display page.
+			'AdditionalFields' => [
+				'DiaChi' => [
+					'class' => 'HTMLTextField',
+					'label-message' => 'banquyen-label-diachi',
+					'help-message' => 'banquyen-help-giaithich2',
+					'required' => true
+				],
+				'ToChuc' => [
+					'class' => 'HTMLTextField',
+					'label-message' => 'banquyen-label-tochuc',
+					'help-message' => 'banquyen-help-giaithich3',
+					'required' => false
+				],
+				'ChucVu' => [
+					'class' => 'HTMLTextField',
+					'label-message' => 'banquyen-label-chucvu',
+					'help-message' => 'banquyen-help-giaithich4',
+					'required' => true
+				],
+				'SoDienThoai' => [
+					'class' => 'HTMLTextField',
+					'label-message' => 'banquyen-label-sdt',
+					'help-message' => 'banquyen-help-giaithich5',
+					'required' => true
+				],
+				'DoiTuong' => [
+					'class' => 'HTMLSelectField',
+					'label-message' => 'banquyen-label-luachon',
+					'options-message' => 'banquyen-list-luachon',
+					'help-message' => 'banquyen-help-giaithich7',
+					'type' => 'textarea',
+					'required' => true,
+				],	
+				'LienKet' => [
+					'label-message' => 'banquyen-label-url',
+					'help-message' => 'banquyen-help-giaithich8',
+					'type' => 'textarea',
+					'rows' => 5,
+					'required' => true
+				],
+				'NoiDung' => [
+					'label-message' => 'banquyen-label-giaithich',
+					'help-message' => 'banquyen-help-giaithich9',
+					'type' => 'textarea',
+					'rows' => 10,
+					'required' => true
+				],
+				'XacNhan1' => [
+					'class' => 'HTMLCheckField',
+					'label-message' => 'banquyen-label-xacnhan1',
+					'required' => true
+				],
+				'XacNhan2' => [
+					'class' => 'HTMLCheckField',
+					'label-message' => 'banquyen-label-xacnhan2',
+					'required' => true
+				],
+				'XacNhan3' => [
+					'class' => 'HTMLCheckField',
+					'label-message' => 'banquyen-label-xacnhan3',
+					'required' => true
+				],
+				'KySo' => [
+					'class' => 'HTMLTextField',
+					'label-message' => 'banquyen-label-chuky',
+					'help-message' => 'banquyen-help-giaithich6',
+					'required' => true
+				]
+			],
+			'FieldsMergeStrategy' => 'replace'
+		];
+			
+		$wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$footerlinks ) {
+			if ( $key === 'places' ) {
+				$footerlinks['contact'] = Html::element( 'a',
+					[
+						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ',  // URL to "Special:Contact"
+						'rel' => 'noreferrer noopener'  // not required, but recommended for security reasons
+					],
+				$skin->msg( 'contactpage-label' )->text()
+				);
+				$footerlinks['copyright'] = Html::element( 'a',
+					[
+						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ/banquyen',  // URL to "Special:Contact"
+						'rel' => 'noreferrer noopener'  // not required, but recommended for security reasons
+					],
+				$skin->msg( 'crpage-label' )->text()
+				);
+			};
+		};
+
 		break;
 	case 'libertygamewiki':
 		$wgHooks['BeforePageDisplay'][] = 'onBeforePageDisplay';

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -2,14 +2,12 @@
 
 use MediaWiki\Actions\ActionEntryPoint;
 use MediaWiki\Html\Html;
-use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\DisabledSpecialPage;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
-
 
 // Per-wiki settings that are incompatible with LocalSettings.php
 switch ( $wi->dbname ) {
@@ -578,9 +576,9 @@ switch ( $wi->dbname ) {
 					'label-message' => 'banquyen-label-chuky',
 					'help-message' => 'banquyen-help-giaithich6',
 					'required' => true,
-				]
+				],
 			],
-			'FieldsMergeStrategy' => 'replace'
+			'FieldsMergeStrategy' => 'replace',
 		];
 			
 		$wgHooks['SkinAddFooterLinks'][] = static function( Skin $skin, string $key, array &$footerlinks ) {

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -315,7 +315,7 @@ switch ( $wi->dbname ) {
 		];
 
 		break;
-	case 'lhmnwiki': // thiết lập Wiki Lớp Học Mật Ngữ (lophocmatngu.wiki)
+	case 'lhmnwiki':
 		// UploadWizard
 		$wgUploadWizardConfig = [
 			'tutorial' => [
@@ -434,7 +434,7 @@ switch ( $wi->dbname ) {
 		}
 		
 		// ContactForm
-		$wgContactConfig['default'] = [ // Biểu mẫu mặc định
+		$wgContactConfig['default'] = [
 			'RecipientEmail' => 'hotro@lophocmatngu.wiki',
 			'SenderName' => 'Liên hệ từ WLHMN',
 			'RequireDetails' => true,
@@ -455,7 +455,7 @@ switch ( $wi->dbname ) {
 			'FieldsMergeStrategy' => null
 		];
 
-		$wgContactConfig['banquyen'] = [ // Biểu mẫu yêu cầu gỡ bỏ
+		$wgContactConfig['banquyen'] = [
 			'RecipientEmail' => 'banquyen@lophocmatngu.wiki',
 			'SenderName' => 'Xử lý bản quyền WLHMN',
 			'RequireDetails' => true,
@@ -464,8 +464,8 @@ switch ( $wi->dbname ) {
 			'SubjectReadonly' => true,
 			'UseCustomBlockMessage' => false,
 			'Redirect' => null,
-			'RLModules' => [], // Resource loader modules to add to the form display page.
-			'RLStyleModules' => [], // Resource loader CSS modules to add to the form display page.
+			'RLModules' => [],
+			'RLStyleModules' => [],
 			'AdditionalFields' => [
 				'DiaChi' => [
 					'class' => 'HTMLTextField',
@@ -540,17 +540,17 @@ switch ( $wi->dbname ) {
 			
 		$wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$footerlinks ) {
 			if ( $key === 'places' ) {
-				$footerlinks['contact'] = Html::element( 'a',
+				$footerlinks['lienhe'] = Html::element( 'a',
 					[
-						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ',  // URL to "Special:Contact"
-						'rel' => 'noreferrer noopener'  // not required, but recommended for security reasons
+						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ',
+						'rel' => 'noreferrer noopener'
 					],
 				$skin->msg( 'contactpage-label' )->text()
 				);
-				$footerlinks['copyright'] = Html::element( 'a',
+				$footerlinks['banquyen'] = Html::element( 'a',
 					[
-						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ/banquyen',  // URL to "Special:Contact"
-						'rel' => 'noreferrer noopener'  // not required, but recommended for security reasons
+						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ/banquyen',
+						'rel' => 'noreferrer noopener'
 					],
 				$skin->msg( 'crpage-label' )->text()
 				);

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -596,7 +596,7 @@ switch ( $wi->dbname ) {
 					[
 						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ/banquyen',
 						'rel' => 'noreferrer noopener',
-					]
+					],
 					$skin->msg( 'crpage-label' )->text()
 				);
 			};

--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -1,12 +1,14 @@
 <?php
 
 use MediaWiki\Actions\ActionEntryPoint;
+use MediaWiki\Html\Html;
 use MediaWiki\Linker\Linker;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\DisabledSpecialPage;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
+
 
 // Per-wiki settings that are incompatible with LocalSettings.php
 switch ( $wi->dbname ) {
@@ -449,9 +451,9 @@ switch ( $wi->dbname ) {
 				'Text' => [
 					'label-message' => 'emailmessage',
 					'type' => 'textarea',
-					'required' => true
-					]
+					'required' => true,
 				],
+			],
 			'FieldsMergeStrategy' => null
 		];
 
@@ -471,25 +473,25 @@ switch ( $wi->dbname ) {
 					'class' => 'HTMLTextField',
 					'label-message' => 'banquyen-label-diachi',
 					'help-message' => 'banquyen-help-giaithich2',
-					'required' => true
+					'required' => true,
 				],
 				'ToChuc' => [
 					'class' => 'HTMLTextField',
 					'label-message' => 'banquyen-label-tochuc',
 					'help-message' => 'banquyen-help-giaithich3',
-					'required' => false
+					'required' => false,
 				],
 				'ChucVu' => [
 					'class' => 'HTMLTextField',
 					'label-message' => 'banquyen-label-chucvu',
 					'help-message' => 'banquyen-help-giaithich4',
-					'required' => true
+					'required' => true,
 				],
 				'SoDienThoai' => [
 					'class' => 'HTMLTextField',
 					'label-message' => 'banquyen-label-sdt',
 					'help-message' => 'banquyen-help-giaithich5',
-					'required' => true
+					'required' => true,
 				],
 				'DoiTuong' => [
 					'class' => 'HTMLSelectField',
@@ -504,55 +506,55 @@ switch ( $wi->dbname ) {
 					'help-message' => 'banquyen-help-giaithich8',
 					'type' => 'textarea',
 					'rows' => 5,
-					'required' => true
+					'required' => true,
 				],
 				'NoiDung' => [
 					'label-message' => 'banquyen-label-giaithich',
 					'help-message' => 'banquyen-help-giaithich9',
 					'type' => 'textarea',
 					'rows' => 10,
-					'required' => true
+					'required' => true,
 				],
 				'XacNhan1' => [
 					'class' => 'HTMLCheckField',
 					'label-message' => 'banquyen-label-xacnhan1',
-					'required' => true
+					'required' => true,
 				],
 				'XacNhan2' => [
 					'class' => 'HTMLCheckField',
 					'label-message' => 'banquyen-label-xacnhan2',
-					'required' => true
+					'required' => true,
 				],
 				'XacNhan3' => [
 					'class' => 'HTMLCheckField',
 					'label-message' => 'banquyen-label-xacnhan3',
-					'required' => true
+					'required' => true,
 				],
 				'KySo' => [
 					'class' => 'HTMLTextField',
 					'label-message' => 'banquyen-label-chuky',
 					'help-message' => 'banquyen-help-giaithich6',
-					'required' => true
+					'required' => true,
 				]
 			],
 			'FieldsMergeStrategy' => 'replace'
 		];
 			
-		$wgHooks['SkinAddFooterLinks'][] = function( Skin $skin, string $key, array &$footerlinks ) {
+		$wgHooks['SkinAddFooterLinks'][] = static function( Skin $skin, string $key, array &$footerlinks ) {
 			if ( $key === 'places' ) {
 				$footerlinks['lienhe'] = Html::element( 'a',
 					[
 						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ',
-						'rel' => 'noreferrer noopener'
+						'rel' => 'noreferrer noopener',
 					],
-				$skin->msg( 'contactpage-label' )->text()
+					$skin->msg( 'contactpage-label' )->text()
 				);
 				$footerlinks['banquyen'] = Html::element( 'a',
 					[
 						'href' => 'https://lophocmatngu.wiki/Đặc_biệt:Liên_hệ/banquyen',
-						'rel' => 'noreferrer noopener'
-					],
-				$skin->msg( 'crpage-label' )->text()
+						'rel' => 'noreferrer noopener',
+					]
+					$skin->msg( 'crpage-label' )->text()
 				);
 			};
 		};


### PR DESCRIPTION
No issue tracker tasks are required.

Forms:
* Default (for any other inquiries) - send to `hotro@lophocmatngu.wiki`
* Copyright removal handling (through Viet Nam's copyright laws) - send to `banquyen@lophocmatngu.wiki`

More technical details on what I changed:
https://www.mediawiki.org/wiki/Extension:ContactPage
https://gerrit.wikimedia.org/g/mediawiki/extensions/ContactPage/+/HEAD/README
https://www.mediawiki.org/wiki/HTMLForm