### PR TITLE
Set smwgConfigFileDir to /srv/mediawiki/

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -17,6 +17,8 @@
  */
 $smwgIgnoreUpgradeKeyCheck = true;
 
+$smwgConfigFileDir = '/srv/mediawiki/';
+
 $smwgNamespacesWithSemanticLinks = [
 	NS_MAIN => true,
 	NS_TALK => false,


### PR DESCRIPTION
Right now it locates in /srv/mediawiki/\<version\>/extensions/SemanticMediaWiki/.