### PR TITLE
T13125: Fix typo in protection level name for googlewiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5251,7 +5251,7 @@ $wgConf->settings += [
 			'bureaucrat',
 		],
 		'+googlewiki' => [
-			'editbureauratprotected',
+			'editbureaucratprotected',
 		],
 		'+gratispaideiawiki' => [
 			'editextendedconfirmedprotected',


### PR DESCRIPTION
Ticket (https://issue-tracker.miraheze.org/T13125) claims the protection doesn't work. b4803e5 added both protection level as well as the right, however protection level name had a typo in it. [$wgRestrictionLevels](https://www.mediawiki.org/wiki/Manual:$wgRestrictionLevels) requires a "list of permission keys that can be selected for each [restriction type](https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:$wgRestrictionTypes)" which means that the key is likely not found and the protection doesn't appear to be working.