### PR TITLE
T13205: Changing license for animalroyalezhwiki and fixing license link for animalroyalewiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2972,6 +2972,7 @@ $wgConf->settings += [
 	],
 	'wgRightsText' => [
 		'animalroyalewiki' => 'Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)',
+		'animalroyalezhwiki' => 'Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)',
 		'connorjwatwiki' => 'Creative Commons Attribution-ShareAlike 2.5 Generic (CC BY-SA 2.5)',
 		'constantnoblewiki' => 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
 		'exlinkwikiwiki' => 'Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)',
@@ -2997,7 +2998,8 @@ $wgConf->settings += [
 	],
 	'wgRightsUrl' => [
 		'default' => '',
-		'animalroyale' => 'https://creativecommons.org/licenses/by-nc-sa/3.0',
+		'animalroyalewiki' => 'https://creativecommons.org/licenses/by-nc-sa/3.0',
+		'animalroyalezhwiki' => 'https://creativecommons.org/licenses/by-nc-sa/3.0',
 		'connorjwatwiki' => 'https://creativecommons.org/licenses/by-sa/2.5',
 		'constantnoblewiki' => 'https://creativecommons.org/publicdomain/zero/1.0/',
 		'exlinkwikiwiki' => 'https://creativecommons.org/licenses/by-sa/3.0',


### PR DESCRIPTION
Addressing https://issue-tracker.miraheze.org/T13205 by adding license from forked from wiki (https://animalroyale.fandom.com/zh/wiki/Super_Animal_Royale_Wiki:%E7%89%88%E6%9D%83 https://meta.miraheze.org/wiki/Special:RequestWikiQueue/54687) as well as fixing an issue with lacking link for animalroyale wiki since a proper DB name wasn't used (there is currently no link).