### PR TITLE
Add mw-empty-elt class to wgExtractsRemoveClasses

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6022,6 +6022,7 @@ $wgConf->settings += [
 			'.noprint',
 			'.noexcerpt',
 			'.sortkey',
+			'.mw-empty-elt',
 		],
 		'+gratispaideiawiki' => [
 			'.metadata',


### PR DESCRIPTION
Should ideally fix issues where empty elements with this class show up in parsing and cause extract extracts to return nothing/"." as the text.