### PR TITLE
Set default `$wgKartographerSrcsetScales` to empty array

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2776,25 +2776,7 @@ $wgConf->settings += [
 		'default' => 'https://tile.openstreetmap.org',
 	],
 	'wgKartographerSrcsetScales' => [
-		'default' => [
-			1.3,
-			1.5,
-			2,
-			2.6,
-			3,
-		],
-		'bluepageswiki' => [
-			1,
-		],
-		'hkrailwiki' => [
-			1,
-		],
-		'isvwiki' => [
-			1,
-		],
-		'leborkwiki' => [
-			1,
-		],
+		'default' => [ ],
 	],
 	'wgKartographerStaticMapframe' => [
 		'default' => false,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2776,7 +2776,7 @@ $wgConf->settings += [
 		'default' => 'https://tile.openstreetmap.org',
 	],
 	'wgKartographerSrcsetScales' => [
-		'default' => [ ],
+		'default' => [],
 	],
 	'wgKartographerStaticMapframe' => [
 		'default' => false,


### PR DESCRIPTION
Since the default tile server is `tile.openstreetmap.org` and that server only supports 1x tiles, it makes sense for the default `$wgKartographerSrcsetScales` to be an empty array which, according to the Kartographer docs, will implicitly include `1`. There shouldn't be overrides for individual wikis unless they use a different tile server which supports tile scaling.

> Doesn't need to start with 1, this happens automatically. Note that most tile servers don't support this at all and thus require setting this to an empty array.

— [Kartographer docs](https://www.mediawiki.org/wiki/Extension:Kartographer#Configuration)