### PR TITLE
Updating RatePage configuration options

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5190,7 +5190,7 @@ $wgConf->settings += [
 
 	// RatePage
 	'wgRPRatingAllowedNamespaces' => [
-		'default' => '0',
+		'default' => [ NS_MAIN ],
 	],
 	'wgRPRatingPageBlacklist' => [
 		'default' => [],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5185,14 +5185,17 @@ $wgConf->settings += [
 	],
 
 	// RatePage
+	'wgRPRatingAllowedNamespaces' => [
+		'default' => '0',
+	],
 	'wgRPRatingPageBlacklist' => [
 		'default' => [],
 	],
-	'wgRPAddSidebarSection' => [
-		'default' => true,
-	],
 	'wgRPSidebarPosition' => [
 		'default' => 2,
+	],
+	'wgRPAddSidebarSection' => [
+		'default' => true,
 	],
 	'wgRPShowResultsBeforeVoting' => [
 		'default' => false,

--- a/ManageWikiNamespaces.php
+++ b/ManageWikiNamespaces.php
@@ -376,17 +376,6 @@ $wgManageWikiNamespacesAdditional = [
 		'help' => '',
 		'requires' => [],
 	],
-	'wgRPRatingAllowedNamespaces' => [
-		'name' => 'Allow RatePage to operate in this namespace?',
-		'from' => 'ratepage',
-		'type' => 'check',
-		'main' => true,
-		'talk' => true,
-		'excluded' => [],
-		'overridedefault' => false,
-		'help' => '',
-		'requires' => [],
-	],
 	'wgUFAllowedNamespaces' => [
 		'name' => 'Allow UserFunctions to operate in this namespace?',
 		'from' => 'userfunctions',

--- a/ManageWikiNamespaces.php
+++ b/ManageWikiNamespaces.php
@@ -376,6 +376,17 @@ $wgManageWikiNamespacesAdditional = [
 		'help' => '',
 		'requires' => [],
 	],
+	'wgRPRatingAllowedNamespaces' => [
+		'name' => 'Allow RatePage to operate in this namespace?',
+		'from' => 'ratepage',
+		'type' => 'check',
+		'main' => true,
+		'talk' => true,
+		'excluded' => [],
+		'overridedefault' => false,
+		'help' => '',
+		'requires' => [],
+	],
 	'wgUFAllowedNamespaces' => [
 		'name' => 'Allow UserFunctions to operate in this namespace?',
 		'from' => 'userfunctions',


### PR DESCRIPTION
Adding the `$wgRPRatingAllowedNamespaces` namespace configuration variable for RatePage per [T13145](https://issue-tracker.miraheze.org/T13145).