### PR TITLE
Undeploy Skin:Eveskin per T13411

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -7305,7 +7305,6 @@ $wi::$disabledExtensions = [
 
 	'chameleon' => 'Incompatible with MediaWiki 1.42',
 	'evelution' => 'Incompatible with MediaWiki 1.42',
-	'eveskin' => 'Incompatible with MediaWiki 1.42',
 	'femiwiki' => 'Incompatible with MediaWiki 1.42',
 	'snapwikiskin' => 'Incompatible with MediaWiki 1.42',
 ];

--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -3779,13 +3779,6 @@ $wgManageWikiExtensions = [
 		'requires' => [],
 		'section' => 'skins',
 	],
-	'eveskin' => [
-		'name' => "Eveskin",
-		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Skin:Eveskin',
-		'conflicts' => false,
-		'requires' => [],
-		'section' => 'skins',
-	],
 	'femiwiki' => [
 		'name' => 'Femiwiki',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Skin:Femiwiki',


### PR DESCRIPTION
Per [T13411](https://issue-tracker.miraheze.org/T13411), [Skin:Eveskin](https://www.mediawiki.org/wiki/Skin:Eveskin) was archived on March 25th as it hasn't been updated to work with MediaWiki 1.42 and the repository for the skin was archived by the creator, therefore it needs to be removed, and as it is already in a disabled state on Miraheze there is no need to globally disable it as an enabled skin on wikis as that has already been done.