### PR TITLE
Configuration change per T13482

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -88,6 +88,7 @@ switch ( $wi->dbname ) {
 		break;
 	case 'constantnoblewiki':
 		$wgDplSettings['maxResultCount'] = 2500;
+		$wgDplSettings['maxCategoryCount'] = 100;
 
 		break;
 	case 'dlfmwiki':


### PR DESCRIPTION
Configuration change for the Constant Noble Wiki to raise maxCategoryResults from the default of 4 to 100 per [T13482](https://issue-tracker.miraheze.org/T13482).