### PR TITLE
Fixed overwrite of default from 86d3e0c

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1738,6 +1738,18 @@ $wgConf->settings += [
 					'alt' => 'Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)',
 				],
 			],
+			'poweredby' => [
+				'mediawiki' => [
+					'src' => 'https://static.wikitide.net/animalroyalewiki/d/da/Poweredby_mediawiki.svg',
+					'url' => 'https://www.mediawiki.org/',
+					'alt' => 'Powered by MediaWiki',
+				],
+				'miraheze' => [
+					'src' => 'https://static.wikitide.net/commonswiki/f/fe/Powered_by_Miraheze_(no_box).svg',
+					'url' => 'https://meta.miraheze.org/wiki/Special:MyLanguage/Miraheze_Meta',
+					'alt' => 'Hosted by Miraheze',
+				],
+			],
 		],
 		'jbcstudioswiki' => [
 			'poweredby' => [


### PR DESCRIPTION
While updating footer icon with appropriate license in my previous commit, apparently it overwrote a default resulting in Miraheze logo disappearing from the footer. This commit is to correct this grave mistake.