### PR TITLE
Updating LocalWiki.php settings for Constantnoblewiki per T13503

### DIFF
--- a/LocalWiki.php
+++ b/LocalWiki.php
@@ -90,6 +90,8 @@ switch ( $wi->dbname ) {
 		$wgDplSettings['maxResultCount'] = 2500;
 		$wgDplSettings['maxCategoryCount'] = 100;
 
+		// All of the below values except for SMW_DV_PVUC, are the defaults for $smwgDVFeatures
+		$smwgDVFeatures = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE | SMW_DV_TIMEV_CM | SMW_DV_PPLB | SMW_DV_PROV_LHNT | SMW_DV_PVUC;
 		break;
 	case 'dlfmwiki':
 		$wgHooks['TranslatePostInitGroups'][] = static function ( &$list, &$deps, &$autoload ) {


### PR DESCRIPTION
Adding the `$smwgDVFeatures` global variable and defining all the default values along with adding `SMW_DV_PVUC` at the end to enable the ["Special property has uniqueness constraint"](https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_uniqueness_constraint) option per [T13503](https://issue-tracker.miraheze.org/T13503).