### PR TITLE
Updating SemanticMediaWiki.php settings for Constantnoblewiki per T13503

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -52,7 +52,9 @@ if ( !class_exists( SMW\Setup::class ) ) {
 
 if ( $wgDBname === 'constantnoblewiki' ) {
 	array_push( $smwgPageSpecialProperties, '_CDAT' );
-
+	
+	$smwgDVFeatures = $smwgDVFeatures | SMW_DV_PVUC;
+	
 	$smwgNamespacesWithSemanticLinks = [
 		NS_MAIN => true,
 		NS_TALK => false,

--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -52,9 +52,9 @@ if ( !class_exists( SMW\Setup::class ) ) {
 
 if ( $wgDBname === 'constantnoblewiki' ) {
 	array_push( $smwgPageSpecialProperties, '_CDAT' );
-	
+
 	$smwgDVFeatures = $smwgDVFeatures | SMW_DV_PVUC;
-	
+
 	$smwgNamespacesWithSemanticLinks = [
 		NS_MAIN => true,
 		NS_TALK => false,


### PR DESCRIPTION
Adding the `$smwgDVFeatures` global variable and defining all the default values along with adding `SMW_DV_PVUC` at the end to enable the ["Special property has uniqueness constraint"](https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_uniqueness_constraint) option per [T13503](https://issue-tracker.miraheze.org/T13503).

This time, this PR shouldn't break their wiki like it did when defined through `LocalSettings.php`.