### PR TITLE
Add securepoll-edit-poll perm to electionadmin on metawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3360,6 +3360,7 @@ $wgConf->settings += [
 			],
 			'electionadmin' => [
 				'securepoll-create-poll' => true,
+				'securepoll-edit-poll' => true,
 			],
 			'global-renamer' => [
 				'centralauth-rename' => true,


### PR DESCRIPTION
This change grants `securepoll-edit-poll` permission to the `electionadmin` group on metawiki.
Without this permission, they will be unable to edit poll settings or correct issues in the configuration via the SecurePoll. As the Community Directors Elections are scheduled to begin in 2 days, it would be greatly appreciated if this change could be reviewed and deployed in a timely manner to ensure everything is ready in advance.
Thanks in advance for your support!