### PR TITLE
Update LocalSettings.php  > RW 1 req per 72h

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4879,7 +4879,7 @@ $wgConf->settings += [
 		'default' => [],
 		'metawiki' => [
 			'requestwiki' => [
-				'user' => [ 2, 86400 ],
+				'user' => [ 1, 259200 ],
 			],
 		],
 	],


### PR DESCRIPTION
Updating requestwiki to enforce 1 request created within 72 hours 

Users are currently gaming the system by resubmitting near-duplicate requests to get an AI re-review, increasing strictness of requestwiki behaviors further prevents bulk-spamming/frivolous requests.