### PR TITLE
Add $wgCitizenEnableCommandPalette

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -595,6 +595,9 @@ $wgConf->settings += [
 	'wgCitizenMaxSearchResults' => [
 		'default' => 6,
 	],
+	'wgCitizenEnableCommandPalette' => [
+		'default' => false,
+	],
 	'wgCitizenEnableCJKFonts' => [
 		'default' => false,
 	],

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3974,6 +3974,15 @@ $wgManageWikiSettings = [
 		'help' => 'Max number of search suggestions',
 		'requires' => [],
 	],
+	'wgCitizenEnableCommandPalette' => [
+		'name' => 'Citizen Enable Command Palette',
+		'from' => 'citizen',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'styling',
+		'help' => 'Enable the experimental command palette feature',
+		'requires' => [],
+	],
 	'wgCitizenEnableCJKFonts' => [
 		'name' => 'Citizen Enable CJK fonts',
 		'from' => 'citizen',


### PR DESCRIPTION
This feature was added in citizen 3.1.0: https://github.com/StarCitizenTools/mediawiki-skins-Citizen/releases/tag/v3.1.0
Creating this as a draft since citizen hasn't been updated to 3.1.0 yet