### PR TITLE
T13612: Add settings for NewUserMessage

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4350,9 +4350,14 @@ $wgConf->settings += [
 	],
 
 	// NewUserMessage configs
+	'wgNewUserSuppressRC' => [
+		'default' => false,
+	],
+	'wgNewUserMinorEdit' => [
+		'default' => true,
+	],
 	'wgNewUserMessageOnAutoCreate' => [
 		'default' => false,
-		'nmfwikiwiki' => true,
 	],
 
 	// nofollow links

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -2570,6 +2570,33 @@ $wgManageWikiSettings = [
 		'help' => 'This configuration variable toggles if the signature of the welcomer should be the one they have set in their preferences.',
 		'requires' => [],
 	],
+	'wgNewUserSuppressRC' => [
+		'name' => 'NewUserMessage Suppress In Recent Changes',
+		'from' => 'newusermessage',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'notifications',
+		'help' => 'Hides the new user message creation from Special:RecentChanges.',
+		'requires' => [],
+	],
+	'wgNewUserMinorEdit' => [
+		'name' => 'NewUserMessage Minor Edit',
+		'from' => 'newusermessage',
+		'type' => 'check',
+		'overridedefault' => true,
+		'section' => 'notifications',
+		'help' => 'Sets the new user message creation as a minor edit.',
+		'requires' => [],
+	],
+	'wgNewUserMessageOnAutoCreate' => [
+		'name' => 'NewUserMessage On Auto Create',
+		'from' => 'newusermessage',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'notifications',
+		'help' => 'Sends a new user message when a new user is auto-created by CentralAuth.',
+		'requires' => [],
+	],
 
 	// Permissions
 	'wgWhitelistRead' => [


### PR DESCRIPTION
Adds all three settings ([docs](https://www.mediawiki.org/wiki/Extension:NewUserMessage#Configuration)) of the extension to ManageWiki which resolves https://issue-tracker.miraheze.org/T13612 (`$wgNewUserMessageOnAutoCreate` was requested, I added the other two ones as well since they weren't in ManageWiki either).

`$wgNewUserMessageOnAutoCreate` will have to be set to true for `nmfwikiwiki` via ManageWiki when this is merged since this was specified in LocalSettings before this change.

