### PR TITLE
Grant 'unfuzzy' right of Ext:Translate to *

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1898,6 +1898,7 @@ $wgManageWikiExtensions = [
 				'*' => [
 					'permissions' => [
 						'translate',
+						'unfuzzy'
 					],
 				],
 				'sysop' => [


### PR DESCRIPTION
This user right has been added to Translate [a while ago](http://phabricator.wikimedia.org/T49177) and is required for translations to be marked as no longer outdated.

This fixes tasks like T13297 and T13523.

Translate grants this permission by default as well: https://github.com/wikimedia/mediawiki-extensions-Translate/blob/master/extension.json#L1524