### PR TITLE
T13467: Remove 'w' from wgExtraInterlanguageLinkPrefixes for commonswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2552,7 +2552,6 @@ $wgConf->settings += [
 		],
 		'+commonswiki' => [
 			'wikimediacommons',
-			'w',
 			'eswiki',
 			'wikispecies',
 		],


### PR DESCRIPTION
Removing `w` from [$wgExtraInterlanguageLinkPrefixes](https://www.mediawiki.org/wiki/Manual:$wgExtraInterlanguageLinkPrefixes) on commonswiki since
* it breaks interwiki links using the `w` prefix for linking to Wikipedia (by moving the links to the language selector, while they are supposed to be in the text)
* not a single page appears to be using `w` as an interlanguage link intentionally (while the others like `eswiki` are used as interlanguage links), leading to many descriptions and templates missing these links in their text
* ULS does not even display a label for interlanguage links using this prefix, thus making them dysfunctional on Vector 2022, the default skin on commonswiki

Task: https://issue-tracker.miraheze.org/T13467