### PR TITLE
Remove SMW hack

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -45,11 +45,6 @@ $smwgPageSpecialProperties = [
 
 $smwgMainCacheType = 'mcrouter';
 
-if ( !class_exists( SMW\Setup::class ) ) {
-	require_once "$IP/extensions/SemanticMediaWiki/src/MediaWiki/HookDispatcherAwareTrait.php";
-	require_once "$IP/extensions/SemanticMediaWiki/src/Setup.php";
-}
-
 if ( $wgDBname === 'constantnoblewiki' ) {
 	array_push( $smwgPageSpecialProperties, '_CDAT' );
 


### PR DESCRIPTION
Now that I fixed race conditions in running install scripts in ManageWiki, this *should* no longer be necessary as scripts now run properly after extension has already been loaded.