### PR TITLE
Fix wikibase namespace contentmodels

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -3550,7 +3550,7 @@ $wgManageWikiExtensions = [
 					'protection' => '',
 					'content' => 0,
 					'aliases' => [],
-					'contentmodel' => 'wikitext',
+					'contentmodel' => 'wikibase-item',
 					'additional' => []
 				],
 				'Item_talk' => [
@@ -3570,7 +3570,7 @@ $wgManageWikiExtensions = [
 					'protection' => '',
 					'content' => 0,
 					'aliases' => [],
-					'contentmodel' => 'wikitext',
+					'contentmodel' => 'wikibase-property',
 					'additional' => []
 				],
 				'Property_talk' => [


### PR DESCRIPTION
I noticed this while having a script try to identify the wikibase namespace on miraheze wikibases
The content model was wrong, so hard to figure
out automatically, unless just looking at the text name>

Example of correct defaults
https://addshore-alpha.wikibase.cloud/w/api.php?action=query&meta=siteinfo&siprop=namespaces|statistics&format=json

Example of currently pre merge bad defaults
https://ortaturk.miraheze.org/w/api.php?action=query&meta=siteinfo&siprop=namespaces|statistics&format=json