### PR TITLE
T13842: Enable $wgTemplateStylesExtenderEnableUnscopingSupport

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5817,6 +5817,12 @@ $wgConf->settings += [
 		],
 	],
 
+	// TemplateStylesExtender
+	'wgTemplateStylesExtenderEnableUnscopingSupport' => [
+		'default' => false,
+		'lostrealitieswiki' => true,
+	],
+
 	// TextExtracts
 	'wgExtractsRemoveClasses' => [
 		'default' => [


### PR DESCRIPTION
Resolves [T13842](https://issue-tracker.miraheze.org/T13842).

$wgTemplateStylesExtenderEnableUnscopingSupport enables support for unscoping TemplateStyles CSS from the default `mw-parser-output` class. Unscoping, by default, would require the `editinterface` permission, so this would not cause a security risk for the wiki.
[Extension:TemplateStylesExtender#Configuration](https://www.mediawiki.org/wiki/Extension:TemplateStylesExtender#Configuration)