### PR TITLE
Enable citizen command palette by default

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -598,7 +598,7 @@ $wgConf->settings += [
 		'default' => 6,
 	],
 	'wgCitizenEnableCommandPalette' => [
-		'default' => false,
+		'default' => true,
 	],
 	'wgCitizenEnableCJKFonts' => [
 		'default' => false,

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -4346,9 +4346,9 @@ $wgManageWikiSettings = [
 		'name' => 'Citizen Enable Command Palette',
 		'from' => 'citizen',
 		'type' => 'check',
-		'overridedefault' => false,
+		'overridedefault' => true,
 		'section' => 'styling',
-		'help' => 'Enable the experimental command palette feature',
+		'help' => 'Enable the command palette instead of the legacy search bar',
 		'requires' => [],
 	],
 	'wgCitizenEnableCJKFonts' => [


### PR DESCRIPTION
The default value of the config option was changed in Citizen recently, as the command palette is now considered stable: https://github.com/StarCitizenTools/mediawiki-skins-Citizen/releases/tag/v3.2.0

Therefore enabling this setting by default, since the maintainer of Citizen recommended doing so and the old search bar has issues.