### PR TITLE
Clean up redundant settings requirements

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -468,11 +468,7 @@ $wgManageWikiSettings = [
 		'overridedefault' => false,
 		'section' => 'other',
 		'help' => 'If enabled, links (&lt;a&gt; tags) will be shown. If disabled, the tags are escaped.',
-		'requires' => [
-			'extensions' => [
-				'rss',
-			],
-		],
+		'requires' => [],
 	],
 	'wgRSSItemMaxLength' => [
 		'name' => 'Description length of RSS items',
@@ -483,11 +479,7 @@ $wgManageWikiSettings = [
 		'overridedefault' => 200,
 		'section' => 'other',
 		'help' => 'The maximum length of an RSS item\'s body',
-		'requires' => [
-			'extensions' => [
-				'rss',
-			],
-		],
+		'requires' => [],
 	],
 	'wgRSSUserAgent' => [
 		'name' => 'RSS User Agent',
@@ -496,11 +488,7 @@ $wgManageWikiSettings = [
 		'overridedefault' => 'MediaWiki RSS extension',
 		'section' => 'other',
 		'help' => 'The User Agent that MediaWiki will use to fetch RSS feeds.',
-		'requires' => [
-			'extensions' => [
-				'rss',
-			],
-		],
+		'requires' => [],
 	],
 	'wgWPBBannerProperty' => [
 		'name' => 'WikidataPageBanner Banner Property',
@@ -2134,7 +2122,6 @@ $wgManageWikiSettings = [
 		'help' => 'Whether to use the optional MultimediaViewer feature.',
 		'requires' => [
 			'extensions' => [
-				'ratepage',
 				'multimediaviewer',
 			],
 		],
@@ -2867,7 +2854,6 @@ $wgManageWikiSettings = [
 		'help' => 'Whether or not Page Previews will only request the intro paragraph from TextExtracts or not',
 		'requires' => [
 			'extensions' => [
-				'popups',
 				'textextracts',
 			],
 		],
@@ -3228,7 +3214,6 @@ $wgManageWikiSettings = [
 		'requires' => [
 			'extensions' => [
 				'textextracts',
-				'wikiseo',
 			],
 		],
 	],
@@ -3242,7 +3227,6 @@ $wgManageWikiSettings = [
 		'requires' => [
 			'extensions' => [
 				'textextracts',
-				'wikiseo',
 			],
 		],
 	],
@@ -3256,7 +3240,6 @@ $wgManageWikiSettings = [
 		'requires' => [
 			'extensions' => [
 				'pageimages',
-				'wikiseo',
 			],
 		],
 	],
@@ -3271,7 +3254,6 @@ $wgManageWikiSettings = [
 		'help' => 'Modern profile tabs for the Cosmos skin when social profile is enabled.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3285,7 +3267,6 @@ $wgManageWikiSettings = [
 		'help' => 'Make avatar round on profile pages for the Cosmos skin when social profile is enabled.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3299,7 +3280,6 @@ $wgManageWikiSettings = [
 		'help' => 'Show edit count on profile pages for the Cosmos skin when social profile is enabled.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3313,7 +3293,6 @@ $wgManageWikiSettings = [
 		'help' => 'Allow users to add a bio from Special:MyPage/bio and display it on their user page?',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3327,7 +3306,6 @@ $wgManageWikiSettings = [
 		'help' => 'Follow redirects from Special:MyPage/bio and display the redirect target as bio instead? (experimental)',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3341,7 +3319,6 @@ $wgManageWikiSettings = [
 		'help' => 'Show user group tags on profile pages for the Cosmos skin when social profile is enabled.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3355,7 +3332,6 @@ $wgManageWikiSettings = [
 		'help' => 'Use social profile avatar in the top banner for the Cosmos skin when social profile is enabled.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3374,7 +3350,6 @@ $wgManageWikiSettings = [
 		'help' => 'User groups to show on profile pages for the Cosmos skin when social profile is enabled. They will be shown in order of priority.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -3390,7 +3365,6 @@ $wgManageWikiSettings = [
 		'help' => 'Number of user group tags to show on profile pages for the Cosmos skin when social profile and the profile group tags are enabled. Min. 1; Max. 5.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'socialprofile',
 			],
 		],
@@ -4030,7 +4004,6 @@ $wgManageWikiSettings = [
 		'help' => 'Enable the Europa theme on infoboxes when using the Cosmos skin, if you have the PortableInfobox extension enabled.',
 		'requires' => [
 			'extensions' => [
-				'cosmos',
 				'portableinfobox',
 			],
 		],


### PR DESCRIPTION
If an extension is specified in 'from', it doesn't need to be specified in 'requires' again.