### PR TITLE
Add TabberNeue configuration options to LocalSettings and ManageWiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5774,9 +5774,6 @@ $wgConf->settings += [
 	],
 
 	// TabberNeue
-	'wgTabberNeueEnableMD5Hash' => [
-		'default' => true,
-	],
 	'wgTabberNeueUpdateLocationOnTabChange' => [
 		'default' => true,
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5777,11 +5777,17 @@ $wgConf->settings += [
 	],
 
 	// TabberNeue
-	'wgTabberNeueUpdateLocationOnTabChange' => [
+	'wgTabberNeueAddTabPrefix' => [
+		'default' => true,
+	],
+	'wgTabberNeueEnableAnimation' => [
 		'default' => true,
 	],
 	'wgTabberNeueParseTabName' => [
 		'default' => false,
+	],
+	'wgTabberNeueUpdateLocationOnTabChange' => [
+		'default' => true,
 	],
 
 	// TemplateStyles

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4153,6 +4153,9 @@ $wgConf->settings += [
 			'RFC' => false,
 		],
 	],
+	'wgEnableProtectionIndicators' => [
+		'default' => false,
+	],
 	'wgActiveUserDays' => [
 		'default' => 30,
 	],
@@ -5778,9 +5781,6 @@ $wgConf->settings += [
 		'default' => true,
 	],
 	'wgTabberNeueParseTabName' => [
-		'default' => false,
-	],
-	'wgEnableProtectionIndicators' => [
 		'default' => false,
 	],
 

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1819,15 +1819,6 @@ $wgManageWikiSettings = [
 		'help' => 'Enables short descritption in site tagline',
 		'requires' => [],
 	],
-	'wgTabberNeueParseTabName' => [
-		'name' => 'TabberNeue Parse Tab Name',
-		'from' => 'tabberneue',
-		'type' => 'check',
-		'overridedefault' => false,
-		'section' => 'parserfunctions',
-		'help' => 'Parse tab name as wikitext.',
-		'requires' => [],
-	],
 	'wgTitleIcon_EnableIconInPageTitle' => [
 		'name' => 'Title Icon: Enable icon on page titles',
 		'from' => 'titleicon',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1393,6 +1393,15 @@ $wgManageWikiSettings = [
 		'help' => 'If enabled, removes (substitutes) templates in signatures.',
 		'requires' => [],
 	],
+	'wgTabberNeueAddTabPrefix' => [
+		'name' => 'TabberNeue Add Tab Prefix',
+		'from' => 'tabberneue',
+		'type' => 'check',
+		'overridedefault' => true,
+		'section' => 'editing',
+		'help' => 'If enabled, tabpanel IDs will be prepended with "tabber-" to avoid conflicts with page headings.',
+		'requires' => [],
+	],
 	'wgTabberNeueEnableAnimation' => [
 		'name' => 'TabberNeue Enable Animation',
 		'from' => 'tabberneue',
@@ -1400,6 +1409,15 @@ $wgManageWikiSettings = [
 		'overridedefault' => true,
 		'section' => 'editing',
 		'help' => 'If enabled, activates smooth scroll animation when changing tabs',
+		'requires' => [],
+	],
+	'wgTabberNeueParseTabName' => [
+		'name' => 'TabberNeue Parse Tab Name',
+		'from' => 'tabberneue',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'editing',
+		'help' => 'If enabled, tab names will be parsed as wikitext. This can have a performance impact and cause unexpected behaviors.',
 		'requires' => [],
 	],
 	'wgTabberNeueUpdateLocationOnTabChange' => [


### PR DESCRIPTION
Added:
- `wgTabberNeueAddTabPrefix` to LocalSettings and ManageWiki
- `wgTabberNeueParseTabName` to LocalSettings and ManageWiki

Removed:
- `wgTabberNeueEnableMD5Hash` (unused by TabberNeue)

Other changes:
- Moved `wgEnableProtectionIndicators` from TabberNeue section

Resolves [T13882](https://issue-tracker.miraheze.org/T13882).

https://www.mediawiki.org/wiki/Extension:TabberNeue#Configuration