### PR TITLE
T13886: Add protection level for stickmancomicwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5328,6 +5328,9 @@ $wgConf->settings += [
 			'sysop',
 			'bureaucrat',
 		],
+		'+stickmancomicwiki' => [
+			'editbureaucratprotected',
+		],
 		'+testwiki' => [
 			'editbureaucratprotected',
 			'editconsulprotected',
@@ -5436,6 +5439,9 @@ $wgConf->settings += [
 			'extendedconfirmed',
 			'moderator',
 			'bureaucrat',
+		],
+		'stickmancomicwiki' => [
+			'editbureaucratprotected',
 		],
 		'testwiki' => [
 			'editbureaucratprotected',


### PR DESCRIPTION
- Added: `editbureaucratprotected` to wgRestrictionLevels and wgAvailableRights for stickmancomicwiki

Resolves [T13886](https://issue-tracker.miraheze.org/T13886).