### PR TITLE
cgwiki: Protection level fix

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5230,7 +5230,11 @@ $wgConf->settings += [
 			'editconsulprotected',
 		],
 		'+cgwiki' => [
-			'editcgprotected',
+			'',
+			'user',
+			'autoconfirmed',
+			'cg',
+			'sysop',
 		],
 		'+cmgwiki' => [
 			'bureaucrat',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3452,11 +3452,6 @@ $wgConf->settings += [
 				'read' => true,
 			],
 		],
-		'+cgwiki' => [
-			'cg' => [
-				'editcgprotected' => true,
-			],
-		],
 		'+cmgwiki' => [
 			'gst' => [
 				'read' => true,
@@ -5372,7 +5367,7 @@ $wgConf->settings += [
 			'editextendedconfirmedprotected',
 		],
 		'cgwiki' => [
-			'editcgprotected'
+			'cg'
 		],
 		'codinghutwiki' => [
 			'editbureaucratprotected',


### PR DESCRIPTION
Rename protection level and define order for cgwiki