### PR TITLE
Fix: typo in wgShortDescriptionEnableTagline/help; Sitenotice.php comment

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1816,7 +1816,7 @@ $wgManageWikiSettings = [
 		'type' => 'check',
 		'overridedefault' => true,
 		'section' => 'parserfunctions',
-		'help' => 'Enables short descritption in site tagline',
+		'help' => 'Enables short description in site tagline',
 		'requires' => [],
 	],
 	'wgTitleIcon_EnableIconInPageTitle' => [

--- a/Sitenotice.php
+++ b/Sitenotice.php
@@ -50,7 +50,7 @@ function wfGlobalSiteNotice( &$siteNotice, $skin ) {
 		</table>
 	EOF;
 }
-/*
+*/
 // }
 
 // Specific wiki SiteNotice


### PR DESCRIPTION
"descritption" -> "description"
End comment at L53 of Sitenotice.php instead of starting a new one.