### PR TITLE
T13922: Override wgTweekiSknGridNone for factoriopluswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6083,6 +6083,16 @@ $wgConf->settings += [
 	'wgTweekiSkinFooterIcons' => [
 		'default' => false,
 	],
+	'wgTweekiSkinGridNone' => [
+		'default' => [
+			'mainoffset' => 1, 
+			'mainwidth' => 10,
+		],
+		'factoriopluswiki' => [
+			'mainoffset' => 0, 
+			'mainwidth' => 12,
+		],
+	],
 	'wgTweekiSkinUseBtnParser' => [
 		'default' => false,
 	],


### PR DESCRIPTION
Adds:
- Default for wgTweekiSkinGridNone
- Override for factoriopluswiki

Resolves [T13922](https://issue-tracker.miraheze.org/T13922).