### PR TITLE
T13930: Set wgMaxUploadSize as 5MB for wikigeniuswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2264,6 +2264,8 @@ $wgConf->settings += [
 		'dragdownwiki' => 1024 * 1024 * 10,
 		/** T12515 - 2MB */
 		'irisstationwiki' => 1024 * 1024 * 2,
+		/** T13930 - 5MB */
+		'wikigeniuswiki' => 1024 * 1024 * 5,
 	],
 	'wgAllowCopyUploads' => [
 		'default' => false,


### PR DESCRIPTION
Resolves [T13930](https://issue-tracker.miraheze.org/T13930).