### PR TITLE
New license icon for cgwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2039,9 +2039,9 @@ $wgConf->settings += [
 			],
 			'copyright' => [
 				'copyright' => [
-					'src' => 'https://static.wikitide.net/lhmnwiki/4/4e/CC-BY-SA-4.svg',
-					'url' => 'https://creativecommons.org/licenses/by-sa/4.0/',
-					'alt' => 'Creative Commons Ghi công - Chia sẻ tương tự 4.0 (CC BY-SA 4.0)',
+					'src' => 'https://static.wikitide.net/cgwiki/2/27/CC_BY-NC-SA-4.svg',
+					'url' => 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+					'alt' => 'Creative Commons Ghi công - Phi thương mại - Chia sẻ tương tự 4.0 (CC BY-SA 4.0)',
 					'height' => "42",
 					'width' => "110",
 				],


### PR DESCRIPTION
From `CC BY-SA` to `CC BY-NC-SA`