### PR TITLE
T13958: Add editinterfaceadminprotected for starstruckwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5342,6 +5342,9 @@ $wgConf->settings += [
 			'sysop',
 			'bureaucrat',
 		],
+		'+starstruckwiki' => [
+			'editinterfaceadminprotected',
+		],
 		'+stickmancomicwiki' => [
 			'editbureaucratprotected',
 		],
@@ -5453,6 +5456,9 @@ $wgConf->settings += [
 			'extendedconfirmed',
 			'moderator',
 			'bureaucrat',
+		],
+		'starstruckwiki' => [
+			'editinterfaceadminprotected',
 		],
 		'stickmancomicwiki' => [
 			'editbureaucratprotected',


### PR DESCRIPTION
Adds `editinterfaceadminprotected` for starstruckwiki to:
- wgRestrictionLevels
- wgAvailableRights

Resolves [T13958](https://issue-tracker.miraheze.org/T13958).