### PR TITLE
Add missing sql table for Extension:Translate

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -1931,6 +1931,7 @@ $wgManageWikiExtensions = [
 				'translate_cache' => "$IP/extensions/Translate/sql/mysql/translate_cache.sql",
 				'translate_groupreviews' => "$IP/extensions/Translate/sql/mysql/translate_groupreviews.sql",
 				'translate_groupstats' => "$IP/extensions/Translate/sql/mysql/translate_groupstats.sql",
+				'translate_message_group_subscriptions' => "$IP/extensions/Translate/sql/mysql/translate_message_group_subscriptions.sql",
 				'translate_messageindex' => "$IP/extensions/Translate/sql/mysql/translate_messageindex.sql",
 				'translate_metadata' => "$IP/extensions/Translate/sql/mysql/translate_metadata.sql",
 				'translate_reviews' => "$IP/extensions/Translate/sql/mysql/translate_reviews.sql",


### PR DESCRIPTION
Backtrace:
```
[121f735b012f0a66102a7db3] /wiki/Special:PageTranslation Wikimedia\Rdbms\DBQueryError: A database query error has occurred. Did you forget to run your application's database schema updater after upgrading or after adding a new extension?

Please see https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:Upgrading and https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:How_to_debug for more information.

Error 1146: Table 'exttestwikibeta.translate_message_group_subscriptions' doesn't exist
Function: MediaWiki\Extension\Translate\MessageGroupProcessing\MessageGroupSubscriptionStore::getSubscriptions
Query: SELECT tmgs_group,tmgs_user_id FROM `translate_message_group_subscriptions` WHERE tmgs_group = 'page-Translate'

Backtrace:

from /srv/mediawiki/1.44/includes/libs/rdbms/database/Database.php(1232)
#0 /srv/mediawiki/1.44/includes/libs/rdbms/database/Database.php(1216): Wikimedia\Rdbms\Database->getQueryException(string, int, string, string)
#1 /srv/mediawiki/1.44/includes/libs/rdbms/database/Database.php(1190): Wikimedia\Rdbms\Database->getQueryExceptionAndLog(string, int, string, string)
#2 /srv/mediawiki/1.44/includes/libs/rdbms/database/Database.php(647): Wikimedia\Rdbms\Database->reportQueryError(string, int, string, string, bool)
#3 /srv/mediawiki/1.44/includes/libs/rdbms/database/Database.php(1367): Wikimedia\Rdbms\Database->query(Wikimedia\Rdbms\Query, string)
#4 /srv/mediawiki/1.44/includes/libs/rdbms/database/DBConnRef.php(127): Wikimedia\Rdbms\Database->select(array, array, array, string, array, array)
#5 /srv/mediawiki/1.44/includes/libs/rdbms/database/DBConnRef.php(351): Wikimedia\Rdbms\DBConnRef->__call(string, array)
#6 /srv/mediawiki/1.44/includes/libs/rdbms/querybuilder/SelectQueryBuilder.php(761): Wikimedia\Rdbms\DBConnRef->select(array, array, array, string, array, array)
#7 /srv/mediawiki/1.44/extensions/Translate/src/MessageGroupProcessing/MessageGroupSubscriptionStore.php(59): Wikimedia\Rdbms\SelectQueryBuilder->fetchResultSet()
#8 /srv/mediawiki/1.44/extensions/Translate/src/MessageGroupProcessing/MessageGroupSubscription.php(270): MediaWiki\Extension\Translate\MessageGroupProcessing\MessageGroupSubscriptionStore->getSubscriptions(array, null)
#9 /srv/mediawiki/1.44/extensions/Translate/src/MessageGroupProcessing/MessageGroupSubscription.php(232): MediaWiki\Extension\Translate\MessageGroupProcessing\MessageGroupSubscription->getSubscriberIdsForGroups(array)
#10 /srv/mediawiki/1.44/extensions/Translate/src/PageTranslation/TranslatablePageMarker.php(572): MediaWiki\Extension\Translate\MessageGroupProcessing\MessageGroupSubscription->getGroupSubscribers(string)
#11 /srv/mediawiki/1.44/extensions/Translate/src/PageTranslation/TranslatablePageMarker.php(382): MediaWiki\Extension\Translate\PageTranslation\TranslatablePageMarker->sendNotifications(array, WikiPageMessageGroup, string, bool)
#12 /srv/mediawiki/1.44/extensions/Translate/src/PageTranslation/PageTranslationSpecialPage.php(340): MediaWiki\Extension\Translate\PageTranslation\TranslatablePageMarker->markForTranslation(MediaWiki\Extension\Translate\PageTranslation\TranslatablePageMarkOperation, MediaWiki\Extension\Translate\PageTranslation\TranslatablePageSettings, MediaWiki\Extension\Translate\PageTranslation\PageTranslationSpecialPage, MediaWiki\User\User)
#13 /srv/mediawiki/1.44/extensions/Translate/src/PageTranslation/PageTranslationSpecialPage.php(193): MediaWiki\Extension\Translate\PageTranslation\PageTranslationSpecialPage->onActionMark(MediaWiki\Title\Title, int)
#14 /srv/mediawiki/1.44/includes/specialpage/SpecialPage.php(734): MediaWiki\Extension\Translate\PageTranslation\PageTranslationSpecialPage->execute(null)
#15 /srv/mediawiki/1.44/includes/specialpage/SpecialPageFactory.php(1731): MediaWiki\SpecialPage\SpecialPage->run(null)
#16 /srv/mediawiki/1.44/includes/actions/ActionEntryPoint.php(499): MediaWiki\SpecialPage\SpecialPageFactory->executePath(string, MediaWiki\Context\RequestContext)
#17 /srv/mediawiki/1.44/includes/actions/ActionEntryPoint.php(143): MediaWiki\Actions\ActionEntryPoint->performRequest()
#18 /srv/mediawiki/1.44/includes/MediaWikiEntryPoint.php(202): MediaWiki\Actions\ActionEntryPoint->execute()
#19 /srv/mediawiki/config/initialise/entrypoints/index.php(98): MediaWiki\MediaWikiEntryPoint->run()
#20 {main}
```