### PR TITLE
Remove duplicated settings and array keys

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -234,9 +234,6 @@ $wgConf->settings += [
 	'wgLogSpamBlacklistHits' => [
 		'default' => true,
 	],
-	'wgTitleBlacklistLogHits' => [
-		'default' => true,
-	],
 
 	// ApprovedRevs
 	'egApprovedRevsAutomaticApprovals' => [
@@ -1548,9 +1545,6 @@ $wgConf->settings += [
 		'default' => false,
 	],
 	'wmgShowPopupsByDefault' => [
-		'default' => false,
-	],
-	'wgWatchlistExpiry' => [
 		'default' => false,
 	],
 
@@ -4335,9 +4329,6 @@ $wgConf->settings += [
 		'default' => false,
 		'zhtranswiki' => 'zh-cn',
 	],
-	'wgResourceLoaderMaxQueryLength' => [
-		'default' => 5000,
-	],
 	'wgCleanSignatures' => [
 		'default' => true,
 	],
@@ -5805,7 +5796,6 @@ $wgConf->settings += [
 			'delete' => 500,
 			'edit' => 500,
 			'unprotect' => 500,
-			'edit' => 500,
 			'rollback' => 500,
 			'revert' => 500,
 			'vote' => 100,

--- a/ManageWikiNamespaces.php
+++ b/ManageWikiNamespaces.php
@@ -182,17 +182,6 @@ $wgManageWikiNamespacesAdditional = [
 		'help' => '',
 		'requires' => [],
 	],
-	'wgWPBNamespaces' => [
-		'name' => 'Enable WikidataPageBanner in this namespace?',
-		'from' => 'wikidatapagebanner',
-		'type' => 'check',
-		'main' => true,
-		'talk' => true,
-		'excluded' => [],
-		'overridedefault' => false,
-		'help' => '',
-		'requires' => [],
-	],
 	'wgCommentStreamsAllowedNamespaces' => [
 		'name' => 'Can comments appear in this namespace?',
 		'from' => 'commentstreams',

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -408,7 +408,6 @@ $wgManageWikiSettings = [
 		'overridedefault' => false,
 		'section' => 'other',
 		'help' => 'Whether or not to enable compatibility with Map pages created with the FANDOM InteractiveMaps extension. Restricted as this is only temporarily enabled for a maintenance script run',
-		'requires' => [],
 		'requires' => [
 			'permissions' => [
 				'managewiki-restricted',
@@ -5418,17 +5417,6 @@ $wgManageWikiSettings = [
 		'overridedefault' => 0,
 		'section' => 'wikibase',
 		'help' => 'Namespace ID of the Item namespace on the upstream Wikibase installation. Leave as-is if unsure.',
-		'requires' => [],
-	],
-	'wmgWikibasePropertyNamespaceID' => [
-		'name' => 'Property Namespace ID',
-		'from' => 'wikibaseclient',
-		'type' => 'integer',
-		'minint' => 0,
-		'maxint' => 9999,
-		'overridedefault' => 120,
-		'section' => 'wikibase',
-		'help' => 'Namespace ID of the Property namespace on the upstream Wikibase installation. Leave as-is if unsure.',
 		'requires' => [],
 	],
 	'wmgWikibaseRepoItemNamespaceID' => [


### PR DESCRIPTION
Found with PHPStorm.
I've removed the first occurrences of the duplicated keys, so there shouldn't be any behavioural changes as the second value overrides the first one anyways.