### PR TITLE
Use noreply@wikitide.org directly

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3350,7 +3350,6 @@ $wgConf->settings += [
 			'host' => 'ssl://smtp-relay.gmail.com',
 			'localhost' => '::1',
 			'port' => 465,
-			'IDHost' => 'wikitide.org',
 			'auth' => false,
 		],
 	],


### PR DESCRIPTION
miraheze.org is technically an alias but we use wikitide.org for like emails from issue tracker and using the actual domain makes things work a little better as well.

DO NOT MERGE YET (this is still not decided for certain)