### PR TITLE
Wikibase: set defaultEntityNamespaces to false

### DIFF
--- a/Wikibase.php
+++ b/Wikibase.php
@@ -19,7 +19,6 @@ $entitySources = [
 		'type' => 'db'
 	],
 ];
-
 $wgWBClientSettings['tmpUnconnectedPagePagePropMigrationStage'] = MIGRATION_NEW;
 
 if ( $wi->isExtensionActive( 'WikibaseLexeme' ) ) {
@@ -27,6 +26,7 @@ if ( $wi->isExtensionActive( 'WikibaseLexeme' ) ) {
 	$wgWBRepoSettings['entityNamespaces']['lexeme'] = 146;
 }
 
+$wgWBRepoSettings['defaultEntityNamespaces'] = false;
 $wgWBRepoSettings['entitySources'] = $entitySources;
 $wgWBRepoSettings['localEntitySourceName'] = 'local';
 $wgWBRepoSettings['entityNamespaces']['item'] = $wmgWikibaseRepoItemNamespaceID;

--- a/Wikibase.php
+++ b/Wikibase.php
@@ -19,6 +19,7 @@ $entitySources = [
 		'type' => 'db'
 	],
 ];
+
 $wgWBClientSettings['tmpUnconnectedPagePagePropMigrationStage'] = MIGRATION_NEW;
 
 if ( $wi->isExtensionActive( 'WikibaseLexeme' ) ) {


### PR DESCRIPTION
The default was changed on MediaWiki 1.44 breaking adding new items and other stuff as it creates 2 namespaces of the same name with different IDs (860 and 120) because it makes Wikibase use 120 but our setup in ManageWikiExtensions uses 860. This can be migrated to 120 at a later time.