### PR TITLE
Temporarily duplicate dynamicpagelist3 to dynamicpagelist4

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -476,6 +476,18 @@ $wgManageWikiExtensions = [
 		],
 		'section' => 'parserhooks',
 	],
+	'dynamicpagelist4' => [
+		'name' => 'DynamicPageList4',
+		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:DynamicPageList4',
+		'conflicts' => 'dynamicpagelist',
+		'requires' => [],
+		'install' => [
+			'mwscript' => [
+				CreateView::class => [],
+			],
+		],
+		'section' => 'parserhooks',
+	],
 	'embedspotify' => [
 		'name' => 'EmbedSpotify',
 		'linkPage' => 'https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:EmbedSpotify',


### PR DESCRIPTION
As part of migration to rename the actual key for it. Needs to run ToggleExtension on DPL4 for DPL3 then again to remove DPL3.