### PR TITLE
Increase RobloxAPI caching expiries

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5541,6 +5541,19 @@ $wgConf->settings += [
 		],
 	],
 
+	// RobloxAPI
+	'wgRobloxAPICachingExpiries' => [
+		'ext-RobloxAPI' => [
+			'*' => 1800,
+			'assetDetails' => 43200,
+			'assetThumbnail' => 7200,
+			'groupData' => 3600,
+			'userAvatarThumbnail' => 3600,
+			'userId' => 86400,
+			'userInfo' => 86400,
+		],
+	],
+
 	// RottenLinks
 	'wgRottenLinksCurlTimeout' => [
 		'default' => 10,


### PR DESCRIPTION
This is done to avoid rate limits. Some data sources, especially assetDetails, are currently barely usable because most requests are rate limited.

Compared to the default config:
* All data sources: 10 mins -> 30 mins
* assetDetails: 10 mins -> 12 hours