### PR TITLE
Globally disable SemanticDrilldown

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -7262,6 +7262,7 @@ $wi::$disabledExtensions = [
 
 	'lingo' => 'Currently broken',
 	'mintydocs' => 'Security vulnerabilities',
+	'semanticdrilldown' => 'Security vulnerabilities; Incompatible with MediaWiki 1.44',
 
 	// Are these still incompatible?
 	'chameleon' => 'Incompatible with MediaWiki 1.44',


### PR DESCRIPTION
The extension has security vulnerabilities and is incompatible with MediaWiki 1.44. Relevant task: T14061