### PR TITLE
T14285: add NS_MAIN to wgMFNamespacesWithoutCollapsibleSections for twistwoodtaleswiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4389,6 +4389,23 @@ $wgConf->settings += [
 	'wgDefaultMobileSkin' => [
 		'default' => 'minerva',
 	],
+	'wgMFNamespacesWithoutCollapsibleSections' => [
+		// See https://github.com/wikimedia/mediawiki-extensions-MobileFrontend?tab=readme-ov-file#wgmfnamespaceswithoutcollapsiblesections
+		'default' => [
+			NS_FILE,
+			NS_CATEGORY,
+			NS_SPECIAL,
+			NS_MEDIA,
+		],
+		'twistwoodtaleswiki' => [
+			// Attempt to replace deprecated wgMFCollapseSectionsByDefault setting
+			NS_MAIN,
+			NS_FILE,
+			NS_CATEGORY,
+			NS_SPECIAL,
+			NS_MEDIA,
+		],
+	],
 	'wgMFAdvancedMobileContributions' => [
 		'default' => true,
 	],


### PR DESCRIPTION
As a potential workaround for the deprecated wgMFCollapseSectionsByDefault setting