### PR TITLE
T14285: Add wgMFNamespacesWithoutCollapsibleSections to ManageWikiNamespaces.php

### DIFF
--- a/ManageWikiNamespaces.php
+++ b/ManageWikiNamespaces.php
@@ -387,4 +387,22 @@ $wgManageWikiNamespacesAdditional = [
 		'help' => '',
 		'requires' => [],
 	],
+	'wgMFNamespacesWithoutCollapsibleSections' => [
+		'name' => 'Disable collapsible sections in this namespace?',
+		'from' => 'mobilefrontend',
+		'type' => 'check',
+		'main' => true,
+		'talk' => true,
+		'excluded' => [],
+		// See https://github.com/wikimedia/mediawiki-extensions-MobileFrontend?tab=readme-ov-file#wgmfnamespaceswithoutcollapsiblesections
+		'overridedefault' => [
+			NS_FILE => true,
+			NS_CATEGORY => true,
+			NS_SPECIAL => true,
+			NS_MEDIA => true,
+			'default' => false,
+		],
+		'help' => 'If enabled, collapsible sections will be disabled in this namespace on mobile devices.',
+		'requires' => [],
+	],
 ];


### PR DESCRIPTION
As a potential workaround for the deprecated wgMFCollapseSectionsByDefault setting

Supersedes https://github.com/miraheze/mw-config/pull/6112, suggested by Skye [here](https://issue-tracker.miraheze.org/T14285#286268)