### PR TITLE
Update help text for $wgLogo in ManageWikiSettings.php

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3657,7 +3657,7 @@ $wgManageWikiSettings = [
 		'type' => 'text',
 		'overridedefault' => "https://$wmgUploadHostname/metawiki/3/35/Miraheze_Logo.svg",
 		'section' => 'styling',
-		'help' => 'This will replace Miraheze\'s default logo. See [[m:Special:MyLanguage/ManageWiki|this link]] for how you can change it. Also sets the value of <code>$wgLogos[\'1x\']</code>.',
+		'help' => 'This will replace Miraheze\'s default logo. See [[m:Help:How_to_change_my_logo_or_favicon|this link]] for how you can change it. Also sets the value of <code>$wgLogos[\'1x\']</code>.',
 		'requires' => [],
 	],
 	'wgMFAutodetectMobileView' => [


### PR DESCRIPTION
There is a dedicated page for changing logos, so use that instead of directing users to a hidden text box on the ManageWiki page.

Translations are not an issue because [[ManageWiki]] was unmarked for translation a long time ago. 