### PR TITLE
T13921: Install ParserPower extension

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -817,6 +817,14 @@ $wgManageWikiExtensions = [
 		],
 		'section' => 'parserhooks',
 	],
+	'parserpower' => [
+		'name' => 'ParserPower',
+		'linkPage' => 'https://www.mediawiki.org/wiki/Extension:ParserPower',
+		'description' => 'A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter.',
+		'conflicts' => 'pageforms',
+		'requires' => [],
+		'section' => 'parserhooks',
+	],
 	'phonos' => [
 		'name' => 'Phonos',
 		'displayname' => 'Phonos',


### PR DESCRIPTION
This pull request adds the ParserPower extension to ManageWiki.

**Changes:**
- Added ParserPower extension configuration to `ManageWikiExtensions.php`
- Extension provides extended parser functions for MediaWiki, particularly for dealing with lists of values with dynamically-specified delimiters
- Added conflict with PageForms extension as specified
- Categorized under 'parserhooks' section

**Extension Details:**
- **Name:** ParserPower
- **Link:** https://www.mediawiki.org/wiki/Extension:ParserPower
- **Description:** A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter
- **Conflicts:** pageforms
- **Section:** parserhooks

This addresses task T13921 for installing the ParserPower extension.