### PR TITLE
Toggle for replacing CodeEditor with CodeMirror

### DIFF
--- a/GlobalSettings.php
+++ b/GlobalSettings.php
@@ -171,6 +171,41 @@ if ( $wi->isExtensionActive( 'VisualEditor' ) ) {
 
 if ( $wi->isExtensionActive( 'CodeMirror' ) ) {
 	$wgDefaultUserOptions['usecodemirror'] = (int)$wmgCodeMirrorEnableDefault;
+	if ( $wmgCodeMirrorReplaceCodeEditor ) {
+		// Taken from WMF's configuration.
+		$wgCodeMirrorEnabledModes['javascript'] = true;
+		$wgCodeMirrorEnabledModes['json'] = true;
+		$wgCodeMirrorEnabledModes['css'] = true;
+		$wgCodeMirrorEnabledModes['lua'] = true;
+		$wgCodeMirrorEnabledModes['vue'] = true;
+		// CodeEditor
+		$wgCodeEditorEnabledModes['javascript'] = false;
+		$wgCodeEditorEnabledModes['json'] = false;
+		$wgCodeEditorEnabledModes['css'] = false;
+		$wgCodeEditorEnabledModes['lua'] = false;
+		$wgCodeEditorEnabledModes['vue'] = false;
+		// AbuseFilter
+		$wgAbuseFilterUseCodeEditor = false;
+		$wgAbuseFilterUseCodeMirror = true;
+		// DataMaps
+		$wgDataMapsUseCodeEditor = false;
+		$wgDataMapsUseCodeMirror = true;
+		// Gadgets
+		$wgGadgetsDefinitionsUseCodeEditor = false;
+		$wgGadgetsDefinitionsUseCodeMirror = true;
+		// JsonConfig
+		$wgJsonConfigUseCodeEditor = false;
+		$wgJsonConfigUseCodeMirror = true;
+		// Scribunto
+		$wgScribuntoUseCodeEditor = false;
+		$wgScribuntoUseCodeMirror = true;
+		// TemplateStyles
+		$wgTemplateStylesUseCodeEditor = false;
+		$wgTemplateStylesUseCodeMirror = true;
+		// UploadWizard
+		$wgUploadWizardUseCodeEditor = false;
+		$wgUploadWizardUseCodeMirror = true;
+	}
 }
 
 if ( $wi->isAnyOfExtensionsActive( 'WikibaseClient', 'WikibaseRepository' ) ) {

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -704,6 +704,9 @@ $wgConf->settings += [
 	'wgCodeMirrorV6' => [
 		'default' => false,
 	],
+	'wmgCodeMirrorReplaceCodeEditor' => [
+		'default' => false,
+	],
 
 	// Comments
 	'wgCommentsDefaultAvatar' => [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -1453,6 +1453,15 @@ $wgManageWikiSettings = [
 		'help' => 'Enables CodeMirror 6, which provides various improvements to the code editor, including code folding and autocompletion.',
 		'requires' => [],
 	],
+	'wmgCodeMirrorReplaceCodeEditor' => [
+		'name' => 'Replace CodeEditor with CodeMirror',
+		'from' => 'codemirror',
+		'type' => 'check',
+		'overridedefault' => false,
+		'section' => 'editing',
+		'help' => 'This replaces the default CodeEditor with CodeMirror for all users.',
+		'requires' => [],
+	],
 
 	// Links
 	'wgArticleCountMethod' => [


### PR DESCRIPTION
Wikimedia are looking to [replace CodeEditor with CodeMirror](https://phabricator.wikimedia.org/T419332), so I thought a toggle for this might be useful. CodeMirror also seemingly has improved support for CSS linting, and doesn't yell at me when I save a file with CSS variables. There is also some autocompletion support for Scribunto.

I took [this particular block](https://github.com/wikimedia/operations-mediawiki-config/blob/a25f8b8/wmf-config/CommonSettings.php#L3020-L3049) from Wikimedia's config and added AbuseFilter ([pending change](https://gerrit.wikimedia.org/r/c/operations/mediawiki-config/+/1268652)) and DataMaps ([pending change](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/DataMaps/+/1271952)) to it. AbuseFilter support is not going to get backported to 1.45, but it's there just in case.