### PR TITLE
Update wgRestrictionLevels and wgAdditionalRights for hypotheticalwea…

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5659,7 +5659,6 @@ $wgConf->settings += [
 			'templateeditor',
 			'extendedconfirmed',
 			'author',
-			'moderator',
 			'sysop',
 			'bureaucrat',
 		],
@@ -5809,7 +5808,6 @@ $wgConf->settings += [
 		'hypotheticalweatherwiki' => [
 			'templateeditor',
 			'extendedconfirmed',
-			'moderator',
 			'bureaucrat',
 		],
 		'infopediawiki' => [


### PR DESCRIPTION
…therwiki

Removing the moderator protection level from my wiki (hypotheticalweatherwiki) as I have renamed the moderator group to something else, and I no longer need this protection level on my wiki. Also, removing it from the wgAdditionalRights since the moderator protection level is being removed.