### PR TITLE
T15278: New Vector-2022 Default Preferences for realitycompromised.miraheze.org

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5339,6 +5339,13 @@ $wgConf->settings += [
 			'usenewrc' => 0,
 			'thumbsize' => 3,
 		],
+		'+realitycompromisedwiki' => [
+			'vector-limited-width' => '0',
+			'vector-page-tools-pinned' => '0',
+			'vector-appearance-pinned' => '0',
+			'vector-font-size' => '1',
+			'vector-theme' => 'night',
+		],
 		'+reviwiki' => [
 			'rcenhancedfilters-disable' => 1,
 			'usenewrc' => 0,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5340,10 +5340,10 @@ $wgConf->settings += [
 			'thumbsize' => 3,
 		],
 		'+realitycompromisedwiki' => [
-			'vector-limited-width' => '0',
-			'vector-page-tools-pinned' => '0',
-			'vector-appearance-pinned' => '0',
-			'vector-font-size' => '1',
+			'vector-limited-width' => 0,
+			'vector-page-tools-pinned' => 0,
+			'vector-appearance-pinned' => 0,
+			'vector-font-size' => 1,
 			'vector-theme' => 'night',
 		],
 		'+reviwiki' => [


### PR DESCRIPTION
Changes to default width, pinned navigation, font size, and theme. See https://issue-tracker.miraheze.org/T15278.