### PR TITLE
Fix fetching of global Echo notifications

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -6054,6 +6054,9 @@ $wgConf->settings += [
 	],
 
 	// Server
+	'wgScriptPath' => [
+		'default' => $wgScriptPath,
+	],
 	'wgArticlePath' => [
 		'default' => '/wiki/$1',
 	],


### PR DESCRIPTION
When global notifications are present, they are listed in the `meta=notifications` response under an additional `sources` key. The client tries to fetch these sources, but all of them result in 404 errors:
<img width="608" height="341" alt="A sequence of cross-wiki notification requests that errored" src="https://github.com/user-attachments/assets/9f0d112d-ad85-4f70-9de0-e9fc5ddaa68f" />
This is because the `sources` list lists the wikis' API endpoints under /api.php, rather than /w/api.php. I traced it back to [`ForeignNotifications::getApiEndpoints`](https://github.com/wikimedia/mediawiki-extensions-Echo/blob/6c46b9b/includes/ForeignNotifications.php#L206-L228) which retrieves script paths from `$wgConf`. But, because Miraheze did not set `$wgScriptPath` in `$wgConf`, the returned value is always blank and the API URL always ends up being `/api.php`.

This pull requests aims to solve that issue by adding `$wgScriptPath` into `$wgConf`. I don't have an environment to test whether it works, but I assume this is the reason why it breaks.