### PR TITLE
Modifying read access on govnpwiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3694,6 +3694,10 @@ $wgConf->settings += [
 				'read' => true,
 			],
 		],
+	    '+govnpwiki' => [
+	        '*' => [
+	           'read' => false;
+	        ],
 		'+famedatawiki' => [
 			'extendedconfirmed' => [
 				'editextendedconfirmedprotected' => true,


### PR DESCRIPTION
Removing read access for everyone (*) user group.