### PR TITLE
Configure GlobalUsage shared repo mappings for govnp and related govnp wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2763,6 +2763,9 @@ $wgConf->settings += [
 		'gpcommonswiki' => 'gpcommonswiki',
 		'gratisdatawiki' => 'gpcommonswiki',
 		'gratispaideiawiki' => 'gpcommonswiki',
+		'govnpcommonswiki' => 'govnpcommonswiki',
+		'govnpwiki' => 'govnpcommonswiki',
+		'hinduwiki' => 'govnpcommonswiki',
 	],
 	'wgGlobalUsagePurgeBacklinks' => [
 		'default' => true,


### PR DESCRIPTION
Update `$wgGlobalUsageSharedRepoWiki` to map govnp-related wikis (`govnpwiki`, `hinduwiki`) to `govnpcommonswiki` for shared file usage tracking. No unrelated changes included.
