### PR TITLE
T14888: Fix fetching of global Echo notifications, attempt 2

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -122,9 +122,6 @@ unset( $proxy, $proxyGlobals, $servers );
 
 $wmgSharedDomainPathPrefix = '';
 
-$wgScriptPath = '/w';
-$wgLoadScript = "$wgScriptPath/load.php";
-
 $wgCanonicalServer = $wi->server;
 
 if ( ( $_SERVER['HTTP_HOST'] ?? '' ) === $wi->getSharedDomain()
@@ -136,10 +133,8 @@ if ( ( $_SERVER['HTTP_HOST'] ?? '' ) === $wi->getSharedDomain()
 	}
 
 	$wmgSharedDomainPathPrefix = "/$wgDBname";
-	$wgScriptPath  = "$wmgSharedDomainPathPrefix/w";
 
 	$wgCanonicalServer = 'https://' . $wi->getSharedDomain();
-	$wgLoadScript = "{$wgCanonicalServer}$wgScriptPath/load.php";
 
 	$wgUseSiteCss = false;
 	$wgUseSiteJs = false;
@@ -147,8 +142,6 @@ if ( ( $_SERVER['HTTP_HOST'] ?? '' ) === $wi->getSharedDomain()
 	// We use load.php directly from auth for custom domains due to CSP
 	$wgCentralAuthSul3SharedDomainRestrictions['allowedEntryPoints'] = [ 'load' ];
 }
-
-$wgScript = "$wgScriptPath/index.php";
 
 $wgResourceBasePath = "$wmgSharedDomainPathPrefix/{$wi->version}";
 $wgExtensionAssetsPath = "$wgResourceBasePath/extensions";
@@ -6060,6 +6053,9 @@ $wgConf->settings += [
 	],
 
 	// Server
+	'wgScriptPath' => [
+		'default' => '/w',
+	],
 	'wgArticlePath' => [
 		'default' => '/wiki/$1',
 	],
@@ -7645,9 +7641,15 @@ extract( $globals );
 $wgDiscordNotificationWikiUrl = $wi->server . str_replace( '$1', '', $wgArticlePath );
 
 if ( $wmgSharedDomainPathPrefix ) {
-	$wgArticlePath = $wmgSharedDomainPathPrefix . $wgArticlePath;
+	$wgScriptPath  = "$wmgSharedDomainPathPrefix/w";
+	$wgArticlePath = "{$wmgSharedDomainPathPrefix}$wgArticlePath";
 	$wgServer = '//' . $wi->getSharedDomain();
+	$wgLoadScript = "{$wgCanonicalServer}$wgScriptPath/load.php";
+} else {
+	$wgLoadScript = "$wgScriptPath/load.php";
 }
+
+$wgScript = "$wgScriptPath/index.php";
 
 $wi->loadExtensions();
 


### PR DESCRIPTION
After #6389, it seems that rest.php on Meta started expecting a path in the form of `/metawiki/w/rest.php`, which is how the script path looks on authwiki. My guess is that someone visited authwiki for Meta, the variable got changed in `$wgConf`, values from `$wgConf` somehow got cached? applying the wrong script path to the main wiki. Note that Wikimedia [does not change `$wgConf`](https://github.com/wikimedia/operations-mediawiki-config/blob/8014b71ed18be460503a3bd717d633c240ee2dd0/wmf-config/CommonSettings.php#L596-L598) on authwiki, only the global variables, so that's what we should probably do here to avoid this issue.

To test this out, check:
- Whether login on the beta cluster still works
- Whether search still works
- Whether cross-wiki notifications allow you to expand the dropdown

Resolves [T14888](https://issue-tracker.miraheze.org/T14888).