### PR TITLE
Update Alpha MW version

### DIFF
--- a/initialise/MirahezeFunctions.php
+++ b/initialise/MirahezeFunctions.php
@@ -69,7 +69,7 @@ class MirahezeFunctions {
 	private const string MEDIAWIKI_DIRECTORY = '/srv/mediawiki/';
 
 	public const array MEDIAWIKI_VERSIONS = [
-		'alpha' => '1.45',
+		'alpha' => '1.46',
 		'beta' => '1.45',
 		'stable' => '1.45',
 	];


### PR DESCRIPTION
Per MacFan's comments in MM, this is necessary for `mwdeploy` to recognise 1.46 as a valid version.