### PR TITLE
T15397: Add wgBucketMaxDataPerPage + configure for sagan4alphawiki

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -419,6 +419,10 @@ $wgConf->settings += [
 	'wgBucketDBuser' => [
 		'default' => 'bucketuser',
 	],
+	'wgBucketMaxDataPerPage' => [
+		'default' => 1000000,
+		'sagan4alphawiki' => 10000000,
+	],
 
 	// Cache
 	'wgCacheDirectory' => [


### PR DESCRIPTION
Resolves T15397

Not sure if 10,000,000 is too high, the wiki currently . Also wondering if I should put underscores in these numbers so you can actually tell they're different, only reason I didn't was because there wasn't any precedent in the file.