### PR TITLE
change/clarify dormancy exemption reasons

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1182,8 +1182,8 @@ $wgConf->settings += [
 	],
 	'wgCreateWikiInactiveExemptReasonOptions' => [
 		'default' => [
-			'Wiki is well-documented, publicly useful, and unlikely to need frequent edits.' => 'comp'
-			'The wiki covers a recurring event and will remain inactive until the next occurrence.' => 'tbg',
+			'Wiki is well-documented, publicly useful, and unlikely to need frequent edits.' => 'comp',
+			'Wiki covers a recurring event and will remain inactive until the next occurrence.' => 'tbg',
 			'Primary contributors are temporarily unavailable but intend to return.' => 'temphardship',
 			'Other exceptional cases at Stewards’ discretion.' => 'other',
 		],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1182,11 +1182,10 @@ $wgConf->settings += [
 	],
 	'wgCreateWikiInactiveExemptReasonOptions' => [
 		'default' => [
-			'Wiki completed and made to be read' => 'comp',
-			'Wiki made for time-based gathering' => 'tbg',
-			'Wiki made to be read' => 'mtr',
-			'Temporary exemption for exceptional hardship, see DPE' => 'temphardship',
-			'Other, see DPE' => 'other',
+			'Wiki is well-documented, publicly useful, and unlikely to need frequent edits.' => 'comp'
+			'The wiki covers a recurring event and will remain inactive until the next occurrence.' => 'tbg',
+			'Primary contributors are temporarily unavailable but intend to return.' => 'temphardship',
+			'Other exceptional cases at Stewards’ discretion.' => 'other',
 		],
 	],
 	'wgCreateWikiRequestCountWarnThreshold' => [


### PR DESCRIPTION
The current "made to be read" reasons aren't very accurate, since technically, every wiki is "made to be read".  The new reasons more accurately reflect the Dormancy Policy. After this change is merged, any wikis classified as 'mtr' will be converted to 'comp'.