### PR TITLE
Add "GeoJSON" to the content models for the Maps extension

### DIFF
--- a/ManageWikiExtensions.php
+++ b/ManageWikiExtensions.php
@@ -698,6 +698,7 @@ $wgManageWikiExtensions = [
 		'conflicts' => false,
 		'contentModels' => [
 			'GeoJson',
+			'GeoJSON',
 		],
 		'requires' => [],
 		'install' => [


### PR DESCRIPTION
Apparently both spellings exist per https://github.com/ProfessionalWiki/Maps/blob/fb82eaea3b0b54d107649495359209e10fee5cac/extension.json#L35-L36