### PR TITLE
Mark 1.45-specific config values

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -3591,10 +3591,10 @@ $wgConf->settings += [
 		'default' => true,
 	],
 	'wgEnableSpecialMute' => [
-		'default' => true,
+		'1.45' => true,
 	],
 	'wgEnableUserEmailMuteList' => [
-		'default' => true,
+		'1.45' => true,
 	],
 
 	// ManageWiki
@@ -6758,7 +6758,7 @@ $wgConf->settings += [
 		'default' => true,
 	],
 	'wgVectorNightMode' => [
-		'default' => [
+		'1.45' => [
 			'logged_out' => false,
 			'logged_in' => true,
 			'beta' => false,


### PR DESCRIPTION
According to changelogs, the Mute-related config values were dropped in 1.46.

Vector's night mode config was also dropped, as can be seen in its absence from https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/skins/Vector/+/refs/heads/REL1_46/skin.json. Surprisingly the same thing didn't happen to Minerva