### PR TITLE
Add 1.46 configuration to LocalSettings.php

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1693,6 +1693,9 @@ $wgConf->settings += [
 		'default' => false,
 		'ysmwikiwiki' => true,
 	],
+	'wgNamespacesWithoutAutoSummaries' => [
+		'1.46' => [],
+	],
 
 	// EditSimilar
 	'wgEditSimilarMaxResultsPool' => [
@@ -1863,7 +1866,10 @@ $wgConf->settings += [
 	],
 
 	'wgWatchlistExpiry' => [
-		'default' => true
+		'default' => true,
+	],
+	'wgEnableWatchlistLabels' => [
+		'1.46' => false,
 	],
 	'wgShortPagesNamespaceExclusions' => [
 		'default' => [],
@@ -5480,6 +5486,12 @@ $wgConf->settings += [
 	],
 	'wmgCodeMirrorEnableDefault' => [
 		'default' => false,
+	],
+	'wgBotPasswordsLimit' => [
+		'1.46' => 100,
+	],
+	'wgUserJsPrefLimit' => [
+		'1.46' => 100,
 	],
 
 	// Preloader


### PR DESCRIPTION
This at the moment doesn't include `wgRestrictedGroups` or `$wgScribuntoEngineConf['luasandbox']['shareInvocationEnv']`. The first of these could probably be added here, but possibly would require more configuration. The second I think could be added as a wmg variable.