### PR TITLE
robots.txt: disallow mobileaction= param

### DIFF
--- a/initialise/entrypoints/robots.php
+++ b/initialise/entrypoints/robots.php
@@ -52,11 +52,13 @@ function wfRobotsGetDefaultRules(): array {
 		'Disallow: /w/',
 		'Disallow: /geoip',
 		'Disallow: /rest_v1/',
-		# All action pages and veaction
+		# All action pages, veaction and mobileaction 
 		'Disallow: /*?action=',
 		'Disallow: /*?*&action=',
 		'Disallow: /*?veaction=',
 		'Disallow: /*?*&veaction=',
+		'Disallow: /*?mobileaction=',
+		'Disallow: /*?*&mobileaction=',
 		# Diffs and permalinks
 		'Disallow: /*?diff=',
 		'Disallow: /*?*&diff=',


### PR DESCRIPTION
Some search engines (ahem, Google) seem to be crawling and indexing these MobileFrontend toggle URLs directly, so it's possible for a search result to drop a desktop user into the mobile view by mistake (and vice versa on mobile). Hopefully this should reduce such cases.