### PR TITLE
Remove skipcaptcha from ManageWiki Permissions blacklist for the user…

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4453,7 +4453,6 @@ $wgConf->settings += [
 			'user' => [
 				'autoconfirmed',
 				'noratelimit',
-				'skipcaptcha',
 				'managewiki-core',
 				'managewiki-extensions',
 				'managewiki-namespaces',


### PR DESCRIPTION
… group

@Universal-Omega and @Reception123 Emiliers, Raidarr and I were having a chat in #miraheze on IRC and Discord. I did not realize we had since blacklisted the `skipcaptcha` user right from the `user` group. It was always just blacklisted from the `*` group, which makes sense. Could we please consider removing this from the `user` group? I think it's a bit too strict.