### PR TITLE
T15830: Disable new ParserMigration defaults

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5311,6 +5311,12 @@ $wgConf->settings += [
 	],
 
 	// ParserMigration
+	'ParserMigrationEnableParsoidArticlePages' => [
+		'default' => false,
+	]
+	'ParserMigrationEnableParsoidDiscussionTools' => [
+		'default' => false,
+	],
 	'wgParserMigrationEnableQueryString' => [
 		'default' => true,
 	],

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5311,10 +5311,16 @@ $wgConf->settings += [
 	],
 
 	// ParserMigration
+	'wgParserMigrationEnableParsoidMobileArticlePages' => [
+		'default' => false,
+	],
+	'wgParserMigrationEnableParsoidMobileTalkPages' => [
+		'default' => false,
+	],
 	'wgParserMigrationEnableParsoidArticlePages' => [
 		'default' => false,
 	],
-	'wgParserMigrationEnableParsoidDiscussionTools' => [
+	'wgParserMigrationEnableParsoidTalkPages' => [
 		'default' => false,
 	],
 	'wgParserMigrationEnableQueryString' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -5311,10 +5311,10 @@ $wgConf->settings += [
 	],
 
 	// ParserMigration
-	'ParserMigrationEnableParsoidArticlePages' => [
+	'wgParserMigrationEnableParsoidArticlePages' => [
 		'default' => false,
-	]
-	'ParserMigrationEnableParsoidDiscussionTools' => [
+	],
+	'wgParserMigrationEnableParsoidDiscussionTools' => [
 		'default' => false,
 	],
 	'wgParserMigrationEnableQueryString' => [


### PR DESCRIPTION
As of MediaWiki 1.46, ParserMigration defaults to enabling Parsoid on articles and discussion pages, which is effectively a blocker for upgrading the farm. This explictly adds false defaults to the changed settings, to at least throw this issue to 1.47.