### PR TITLE
Footer icons for doorswiki per T15870

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -2081,6 +2081,29 @@ $wgConf->settings += [
 				],
 			],
 		],
+		'doorswiki' => [
+			'hostedby' => [
+				'miraheze' => [
+					'src' => 'https://static.wikitide.net/utgwiki/8/81/Miraheze_badge.svg',
+					'url' => 'https://meta.miraheze.org/wiki/Special:MyLanguage/Miraheze',
+					'alt' => 'Hosted by Miraheze',
+				],
+			],
+			'poweredby' => [
+				'mediawiki' => [
+					'src' => 'https://static.wikitide.net/utgwiki/b/b0/PoweredByMediaWiki.svg',
+					'url' => 'https://www.mediawiki.org',
+					'alt' => 'Powered by MediaWiki',
+				],
+			],
+			'copyright' => [
+				'copyright' => [
+					'src' => 'https://static.wikitide.net/utgwiki/0/0f/Badge-ccbysa.svg',
+					'url' => 'https://creativecommons.org/licenses/by-sa/4.0/',
+					'alt' => 'Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)',
+				],
+			],
+		],
 		'dragonbloxwiki' => [
 			'poweredby' => [
 				'mediawiki' => [


### PR DESCRIPTION
This adds custom footer icons for the [DOORS Wiki](https://doorsgame.wiki/) per [T15870](https://issue-tracker.miraheze.org/T15870) on the Issue Tracker.