### PR TITLE
Enable Speedscope extension on prod

### DIFF
--- a/GlobalExtensions.php
+++ b/GlobalExtensions.php
@@ -38,6 +38,7 @@ wfLoadExtensions( [
 	'Scribunto',
 	// 'SecureLinkFixer',
 	'SpamBlacklist',
+	'Speedscope',
 	// 'StopForumSpam',
 	'TitleBlacklist',
 	'TorBlock',

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -9,7 +9,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 
 $wgSpeedscopeEndpoint = 'https://speedscope.wikitide.net';
 $wgSpeedscopeEnvironment = str_starts_with( wfHostname(), 'test' ) ? 'beta' : 'prod';
-$wgSpeedscopeExcludedEntryPoints = ['cli', 'RunSingleJob'];
+$wgSpeedscopeExcludedEntryPoints = [ 'cli', 'RunSingleJob' ];
 $wgSpeedscopeExposeCPUInfo = false;
 $wgSpeedscopeSamplingRates = [
 	'prod' => 0,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -7,14 +7,15 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
 }
 
-if ( str_starts_with( wfHostname(), 'test' ) ) {
-	$wgSpeedscopeEndpoint = 'https://speedscope.wikitide.net';
-	$wgSpeedscopeEnvironment = 'beta';
-	$wgSpeedscopeExposeCPUInfo = false;
-	$wgSpeedscopeSamplingRates = [];
-	require_once "$IP/extensions/Speedscope/bootstrap.php";
-	wfLoadExtension( 'Speedscope' );
-}
+$wgSpeedscopeEndpoint = 'https://speedscope.wikitide.net';
+$wgSpeedscopeEnvironment = str_starts_with( wfHostname(), 'test' ) ? 'beta' : 'prod';
+$wgSpeedscopeExcludedEntryPoints = ['cli', 'RunSingleJob'];
+$wgSpeedscopeExposeCPUInfo = false;
+$wgSpeedscopeSamplingRates = [
+	'prod' => 0,
+];
+$wgSpeedscopeLogToStatsd = false;
+require_once "$IP/extensions/Speedscope/bootstrap.php";
 
 if ( PHP_SAPI !== 'cli' ) {
 	header( "Cache-control: no-cache" );

--- a/rpc/RunSingleJob.php
+++ b/rpc/RunSingleJob.php
@@ -24,6 +24,7 @@
 use MediaWiki\Exception\MWExceptionHandler;
 use MediaWiki\Extension\EventBus\JobExecutor;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Profiler\ProfilingContext;
 
 if ( $_SERVER['REQUEST_METHOD'] !== 'POST' ) {
 	http_response_code( 405 );
@@ -51,7 +52,7 @@ define( 'MW_DB', $event['database'] );
 
 require_once __DIR__ . '/../initialise/MirahezeFunctions.php';
 require MirahezeFunctions::getMediaWiki( 'includes/WebStart.php' );
-MediaWiki\Profiler\ProfilingContext::singleton()->init( 'miraheze', MW_ENTRY_POINT );
+ProfilingContext::singleton()->init( 'miraheze', MW_ENTRY_POINT );
 
 // fatals but not random I/O warnings
 error_reporting( E_ERROR );

--- a/rpc/RunSingleJob.php
+++ b/rpc/RunSingleJob.php
@@ -45,11 +45,13 @@ if ( !isset( $event['database'] ) ) {
 	throw new Exception( 'Invalid event received! ' . json_encode( $event ) );
 }
 
+define( 'MW_ENTRY_POINT', 'RunSingleJob' );
 define( 'MEDIAWIKI_JOB_RUNNER', 1 );
 define( 'MW_DB', $event['database'] );
 
 require_once __DIR__ . '/../initialise/MirahezeFunctions.php';
 require MirahezeFunctions::getMediaWiki( 'includes/WebStart.php' );
+MediaWiki\Profiler\ProfilingContext::singleton()->init( 'miraheze', MW_ENTRY_POINT );
 
 // fatals but not random I/O warnings
 error_reporting( E_ERROR );


### PR DESCRIPTION
Set the sampling rate to `0` for now so we can enable sampling in a separate deployment.

Also add MW_ENTRY_POINT and ProfilingContext::init() to RunSingleJob.php, per https://github.com/wikimedia/operations-mediawiki-config/commit/ee7a7b8055ea04d96ce0dbd33a4d928c11d11efb

Part of T14537