### PR TITLE
T15205: move less frequently used domains in the CSP to ManageWiki

### DIFF
--- a/ContentSecurityPolicy.php
+++ b/ContentSecurityPolicy.php
@@ -5,12 +5,14 @@ $wgCSPHeader = [
 	'useNonces' => false,
 ];
 
-// Default CSP for all wikis
-$wgMirahezeMagicCSPHeaderDefault = [
+/**
+ * Domains that are essential to the operation of the farm and are therefore
+ * always present in the CSP of every wiki. Cannot be removed via ManageWiki.
+ */
+$wgMirahezeMagicCSPHeaderEssential = [
 	'default-src' => [
 		"'self'",
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
 	],
@@ -20,37 +22,10 @@ $wgMirahezeMagicCSPHeaderDefault = [
 		"'unsafe-inline'",
 		"'unsafe-eval'",
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'*.wikimedia.org',
-		'*.wikipedia.org',
-		'*.wikibooks.org',
-		'*.wiktionary.org',
-		'*.wikiquote.org',
-		'*.wikisource.org',
-		'*.wikiversity.org',
-		'*.wikinews.org',
-		'*.wikivoyage.org',
-		'mediawiki.org',
-		'*.mediawiki.org',
-		'wikidata.org',
-		'www.gstatic.com',
-		'www.google.com',
-		'apis.google.com',
-		'platform.twitter.com',
-		'ajax.cloudflare.com',
-		'cdnjs.cloudflare.com',
-		'cdn.jsdelivr.net',
-		'fastly.jsdelivr.net',
-		'cdn.syndication.twimg.com',
-		'openlayers.org',
 		'hcaptcha.com',
 		'*.hcaptcha.com',
-		'bandcamp.com',
-		'challenges.cloudflare.com',
-		'www.youtube.com',
-		'tally.so'
 	],
 	'style-src' => [
 		"'self'",
@@ -59,31 +34,10 @@ $wgMirahezeMagicCSPHeaderDefault = [
 		'miraheze.org',
 		'wikitide.org',
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'*.wikimedia.org',
-		'*.wikipedia.org',
-		'*.wikibooks.org',
-		'*.wiktionary.org',
-		'*.wikiquote.org',
-		'*.wikisource.org',
-		'*.wikiversity.org',
-		'*.wikinews.org',
-		'*.wikivoyage.org',
-		'mediawiki.org',
-		'*.mediawiki.org',
-		'wikidata.org',
-		'www.gstatic.com',
-		'fonts.googleapis.com',
-		'cdn.jsdelivr.net',
-		'fastly.jsdelivr.net',
-		'cdnjs.cloudflare.com',
-		'platform.twitter.com',
-		'ton.twimg.com',
 		'hcaptcha.com',
 		'*.hcaptcha.com',
-		'use.typekit.net'
 	],
 	'img-src' => [
 		'blob:',
@@ -92,168 +46,754 @@ $wgMirahezeMagicCSPHeaderDefault = [
 		'miraheze.org',
 		'wikitide.org',
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'upload.wikimedia.org',
-		'thumb.wikimedia.org',
-		'wikimedia.org',
-		'maps.google.com',
-		'www.gstatic.com',
-		'maxcdn.bootstrapcdn.com',
-		'*.twimg.com',
-		'i.imgur.com',
-		'image.tmdb.org',
-		'*.googleusercontent.com',
-		'*.fontawesome.com',
-		'*.dropboxstatic.com',
-		'*.redd.it',
-		'*.redditmedia.com',
-		'mirrors.creativecommons.org',
-		'www.gnu.org',
-		'cdn.pixabay.com',
-		'cdn.geogebra.org',
-		'docs.blender.org',
-		'*.imgbox.com',
-		'tile.openstreetmap.org',
-		'*.tile.openstreetmap.org',
-		'cdn.discordapp.com',
-		'*.fastly.net',
-		'minotar.net',
-		'db.onlinewebfonts.com',
-		'openlayers.org',
-		'discordapp.com',
-		'imgbb.com',
-		'postimages.org',
-		'platform.twitter.com',
-		'syndication.twitter.com',
-		'img.newspapers.com',
-		'storage.googleapis.com',
-		'*.fbcdn.net',
-		'i.ytimg.com',
-		'*.imgbb.com',
-		'simgbb.com',
-		'*.simgbb.com',
-		'ibb.co',
-		'*.ibb.co',
-		'*.postimages.org',
-		'postimgs.org',
-		'*.postimgs.org',
-		'postimg.cc',
-		'*.postimg.cc',
-		'*.rbxcdn.com',
-		'minecraft.wiki',
-		'cdn.jsdelivr.net',
-		'mc-heads.net'
 	],
 	'font-src' => [
 		"'self'",
 		'data:',
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'fonts.gstatic.com',
-		'fonts.googleapis.com',
-		'cdnjs.cloudflare.com',
-		'cdn.jsdelivr.net',
-		'fastly.jsdelivr.net',
-		'db.onlinewebfonts.com',
-		'upload.wikimedia.org',
-		'use.typekit.net'
 	],
 	'media-src' => [
 		"'self'",
 		'blob:',
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'upload.wikimedia.org',
-		'embed.nicovideo.jp',
-		'*.youtube.com',
-		'*.youtube-nocookie.com',
-		'player.twitch.tv',
-		'clips.twitch.tv',
-		'player.vimeo.com',
-		'apis.google.com',
-		'bandcamp.com',
-		'cdn.jsdelivr.net'
 	],
 	'frame-src' => [
 		"'self'",
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'www.google.com',
-		'docs.google.com',
-		'apis.google.com',
-		'calendar.google.com',
-		'drive.google.com',
-		'web.libera.chat',
-		'snap.berkeley.edu',
-		'*.youtube-nocookie.com',
-		'www.youtube.com',
-		'player.twitch.tv',
-		'platform.twitter.com',
-		'discord.com',
-		'discordapp.com',
-		'embed.nicovideo.jp',
-		'syndication.twitter.com',
-		'open.spotify.com',
-		'www.gofundme.com',
-		'archive.org',
-		'w.soundcloud.com',
-		'query.wikidata.org',
-		'player.vimeo.com',
-		'www.bing.com',
-		'lucid.app',
-		'scratch.mit.edu',
 		'hcaptcha.com',
 		'*.hcaptcha.com',
-		'bandcamp.com',
-		'challenges.cloudflare.com',
-		'clips.twitch.tv',
-		'video.fastly.steamstatic.com',
-		'shared.fastly.steamstatic.com',
-		'*.instatus.com',
-		'tally.so'
 	],
 	'connect-src' => [
 		"'self'",
 		'blob:',
 		'*.miraheze.org',
-		'*.mirabeta.org',
 		'*.wikitide.org',
 		'*.wikitide.net',
-		'www.wikidata.org',
-		'*.wikipedia.org',
-		'www.mediawiki.org',
-		'*.wikimedia.org',
-		'*.wikinews.org',
-		'*.wiktionary.org',
-		'cdn.jsdelivr.net',
-		'fastly.jsdelivr.net',
-		'storage.googleapis.com',
-		'*.youtube-nocookie.com',
 		'hcaptcha.com',
 		'*.hcaptcha.com',
-		'1.1.1.1',
-		'translate.googleapis.com',
-		'games.roblox.com',
-		'economy.roblox.com',
-		'discord.com',
-		'discordapp.com',
-		'api.steampowered.com',
-		'*.instatus.com'
 	],
 ];
 
-// Add nexttide.org to beta
+/**
+ * Third party services a wiki can allow content from.
+ *
+ * The key must be stable. The label is what gets shown on ManageWiki
+ */
+$wgMirahezeMagicCSPServices = [
+	'adobe-fonts' => [
+		'label' => 'Adobe Fonts (use.typekit.net)',
+		'sources' => [
+			'style-src' => [
+				'use.typekit.net',
+			],
+			'font-src' => [
+				'use.typekit.net',
+			],
+		],
+	],
+	'bandcamp' => [
+		'label' => 'Bandcamp',
+		'sources' => [
+			'script-src' => [
+				'bandcamp.com',
+			],
+			'media-src' => [
+				'bandcamp.com',
+			],
+			'frame-src' => [
+				'bandcamp.com',
+			],
+		],
+	],
+	'bing' => [
+		'label' => 'Bing',
+		'sources' => [
+			'frame-src' => [
+				'www.bing.com',
+			],
+		],
+	],
+	'blender' => [
+		'label' => 'Blender (docs.blender.org)',
+		'sources' => [
+			'img-src' => [
+				'docs.blender.org',
+			],
+		],
+	],
+	'bootstrapcdn' => [
+		'label' => 'Bootstrap (maxcdn.bootstrapcdn.com)',
+		'sources' => [
+			'img-src' => [
+				'maxcdn.bootstrapcdn.com',
+			],
+		],
+	],
+	'cloudflare' => [
+		'label' => 'Cloudflare',
+		'sources' => [
+			'script-src' => [
+				'ajax.cloudflare.com',
+				'cdnjs.cloudflare.com',
+			],
+			'style-src' => [
+				'cdnjs.cloudflare.com',
+			],
+			'font-src' => [
+				'cdnjs.cloudflare.com',
+			],
+			'connect-src' => [
+				'1.1.1.1',
+			],
+		],
+	],
+	'cloudflare-turnstile' => [
+		'label' => 'Cloudflare Turnstile',
+		'sources' => [
+			'script-src' => [
+				'challenges.cloudflare.com',
+			],
+			'frame-src' => [
+				'challenges.cloudflare.com',
+			],
+		],
+	],
+	'creative-commons' => [
+		'label' => 'Creative Commons (mirrors.creativecommons.org)',
+		'sources' => [
+			'img-src' => [
+				'mirrors.creativecommons.org',
+			],
+		],
+	],
+	'discord' => [
+		'label' => 'Discord',
+		'sources' => [
+			'img-src' => [
+				'cdn.discordapp.com',
+				'discordapp.com',
+			],
+			'frame-src' => [
+				'discord.com',
+				'discordapp.com',
+			],
+			'connect-src' => [
+				'discord.com',
+				'discordapp.com',
+			],
+		],
+	],
+	'dropbox' => [
+		'label' => 'Dropbox (image embeds from dropboxstatic.com)',
+		'sources' => [
+			'img-src' => [
+				'*.dropboxstatic.com',
+			],
+		],
+	],
+	'facebook' => [
+		'label' => 'Facebook (image embeds from fbcdn.net)',
+		'sources' => [
+			'img-src' => [
+				'*.fbcdn.net',
+			],
+		],
+	],
+	'fastly' => [
+		'label' => 'Fastly',
+		'sources' => [
+			'img-src' => [
+				'*.fastly.net',
+			],
+		],
+	],
+	'font-awesome' => [
+		'label' => 'Font Awesome',
+		'sources' => [
+			'img-src' => [
+				'*.fontawesome.com',
+			],
+		],
+	],
+	'geogebra' => [
+		'label' => 'GeoGebra (image embeds from cdn.geogebra.org)',
+		'sources' => [
+			'img-src' => [
+				'cdn.geogebra.org',
+			],
+		],
+	],
+	'gnu' => [
+		'label' => 'GNU (image embeds from www.gnu.org)',
+		'sources' => [
+			'img-src' => [
+				'www.gnu.org',
+			],
+		],
+	],
+	'gofundme' => [
+		'label' => 'GoFundMe (iframe embeds from www.gofundme.com)',
+		'sources' => [
+			'frame-src' => [
+				'www.gofundme.com',
+			],
+		],
+	],
+	'google' => [
+		'label' => 'Google (various Google services)',
+		'sources' => [
+			'script-src' => [
+				'www.google.com',
+				'www.gstatic.com',
+				'apis.google.com',
+			],
+			'style-src' => [
+				'www.gstatic.com',
+			],
+			'img-src' => [
+				'maps.google.com',
+				'www.gstatic.com',
+				'*.googleusercontent.com',
+				'storage.googleapis.com',
+			],
+			'media-src' => [
+				'apis.google.com',
+			],
+			'frame-src' => [
+				'www.google.com',
+				'docs.google.com',
+				'apis.google.com',
+				'calendar.google.com',
+				'drive.google.com',
+			],
+			'connect-src' => [
+				'storage.googleapis.com',
+				'translate.googleapis.com',
+			],
+		],
+	],
+	'google-fonts' => [
+		'label' => 'Google Fonts',
+		'sources' => [
+			'style-src' => [
+				'fonts.googleapis.com',
+			],
+			'font-src' => [
+				'fonts.googleapis.com',
+				'fonts.gstatic.com',
+			],
+		],
+	],
+	'imgbb' => [
+		'label' => 'ImgBB',
+		'sources' => [
+			'img-src' => [
+				'imgbb.com',
+				'*.imgbb.com',
+				'simgbb.com',
+				'*.simgbb.com',
+				'ibb.co',
+				'*.ibb.co',
+			],
+		],
+	],
+	'imgbox' => [
+		'label' => 'imgbox',
+		'sources' => [
+			'img-src' => [
+				'*.imgbox.com',
+			],
+		],
+	],
+	'imgur' => [
+		'label' => 'Imgur',
+		'sources' => [
+			'img-src' => [
+				'i.imgur.com',
+			],
+		],
+	],
+	'instatus' => [
+		'label' => 'Instatus',
+		'sources' => [
+			'frame-src' => [
+				'*.instatus.com',
+			],
+			'connect-src' => [
+				'*.instatus.com',
+			],
+		],
+	],
+	'internet-archive' => [
+		'label' => 'Internet Archive',
+		'sources' => [
+			'frame-src' => [
+				'archive.org',
+			],
+		],
+	],
+	'jsdelivr' => [
+		'label' => 'jsDelivr',
+		'sources' => [
+			'script-src' => [
+				'cdn.jsdelivr.net',
+				'fastly.jsdelivr.net',
+			],
+			'style-src' => [
+				'cdn.jsdelivr.net',
+				'fastly.jsdelivr.net',
+			],
+			'img-src' => [
+				'cdn.jsdelivr.net',
+			],
+			'font-src' => [
+				'cdn.jsdelivr.net',
+				'fastly.jsdelivr.net',
+			],
+			'media-src' => [
+				'cdn.jsdelivr.net',
+			],
+			'connect-src' => [
+				'cdn.jsdelivr.net',
+				'fastly.jsdelivr.net',
+			],
+		],
+	],
+	'libera-chat' => [
+		'label' => 'Libera Chat',
+		'sources' => [
+			'frame-src' => [
+				'web.libera.chat',
+			],
+		],
+	],
+	'lucid' => [
+		'label' => 'Lucid Chart (iframe embeds from lucid.app)',
+		'sources' => [
+			'frame-src' => [
+				'lucid.app',
+			],
+		],
+	],
+	'minecraft-wiki' => [
+		'label' => 'Minecraft Wiki (image embeds from minecraft.wiki)',
+		'sources' => [
+			'img-src' => [
+				'minecraft.wiki',
+			],
+		],
+	],
+	'minotar' => [
+		'label' => 'Minotar (image embeds from minotar.net)',
+		'sources' => [
+			'img-src' => [
+				'minotar.net',
+			],
+		],
+	],
+	'mc-heads' => [
+		'label' => 'MC Heads (image embeds from mc-heads.net)',
+		'sources' => [
+			'img-src' => [
+				'mc-heads.net',
+			],
+		],
+	],
+	'newspapers-com' => [
+		'label' => 'newspapers.com (image embeds)',
+		'sources' => [
+			'img-src' => [
+				'img.newspapers.com',
+			],
+		],
+	],
+	'niconico' => [
+		'label' => 'Niconico',
+		'sources' => [
+			'media-src' => [
+				'embed.nicovideo.jp',
+			],
+			'frame-src' => [
+				'embed.nicovideo.jp',
+			],
+		],
+	],
+	'onlinewebfonts' => [
+		'label' => 'OnlineWebFonts',
+		'sources' => [
+			'img-src' => [
+				'db.onlinewebfonts.com',
+			],
+			'font-src' => [
+				'db.onlinewebfonts.com',
+			],
+		],
+	],
+	'openlayers' => [
+		'label' => 'OpenLayers',
+		'sources' => [
+			'script-src' => [
+				'openlayers.org',
+			],
+			'img-src' => [
+				'openlayers.org',
+			],
+		],
+	],
+	'openstreetmap' => [
+		'label' => 'OpenStreetMap',
+		'sources' => [
+			'img-src' => [
+				'tile.openstreetmap.org',
+				'*.tile.openstreetmap.org',
+			],
+		],
+	],
+	'pixabay' => [
+		'label' => 'Pixabay (cdn.pixabay.com)',
+		'sources' => [
+			'img-src' => [
+				'cdn.pixabay.com',
+			],
+		],
+	],
+	'postimage' => [
+		'label' => 'PostImage',
+		'sources' => [
+			'img-src' => [
+				'postimages.org',
+				'*.postimages.org',
+				'postimgs.org',
+				'*.postimgs.org',
+				'postimg.cc',
+				'*.postimg.cc',
+			],
+		],
+	],
+	'reddit' => [
+		'label' => 'Reddit (image embeds)',
+		'sources' => [
+			'img-src' => [
+				'*.redd.it',
+				'*.redditmedia.com',
+			],
+		],
+	],
+	'roblox' => [
+		'label' => 'Roblox',
+		'sources' => [
+			'img-src' => [
+				'*.rbxcdn.com',
+			],
+			'connect-src' => [
+				'games.roblox.com',
+				'economy.roblox.com',
+			],
+		],
+	],
+	'scratch' => [
+		'label' => 'Scratch (scratch.mit.edu)',
+		'sources' => [
+			'frame-src' => [
+				'scratch.mit.edu',
+			],
+		],
+	],
+	'snap' => [
+		'label' => 'Snap! (snap.berkeley.edu)',
+		'sources' => [
+			'frame-src' => [
+				'snap.berkeley.edu',
+			],
+		],
+	],
+	'soundcloud' => [
+		'label' => 'SoundCloud (iframe embeds from w.soundcloud.com)',
+		'sources' => [
+			'frame-src' => [
+				'w.soundcloud.com',
+			],
+		],
+	],
+	'spotify' => [
+		'label' => 'Spotify (iframe embeds from open.spotify.com)',
+		'sources' => [
+			'frame-src' => [
+				'open.spotify.com',
+			],
+		],
+	],
+	'steam' => [
+		'label' => 'Steam',
+		'sources' => [
+			'frame-src' => [
+				'video.fastly.steamstatic.com',
+				'shared.fastly.steamstatic.com',
+			],
+			'connect-src' => [
+				'api.steampowered.com',
+			],
+		],
+	],
+	'tally' => [
+		'label' => 'tally.so',
+		'sources' => [
+			'script-src' => [
+				'tally.so',
+			],
+			'frame-src' => [
+				'tally.so',
+			],
+		],
+	],
+	'the-movie-database' => [
+		'label' => 'The Movie Database (image embeds from image.tmdb.org)',
+		'sources' => [
+			'img-src' => [
+				'image.tmdb.org',
+			],
+		],
+	],
+	'twitch' => [
+		'label' => 'Twitch',
+		'sources' => [
+			'media-src' => [
+				'player.twitch.tv',
+				'clips.twitch.tv',
+			],
+			'frame-src' => [
+				'player.twitch.tv',
+				'clips.twitch.tv',
+			],
+		],
+	],
+	'twitter' => [
+		'label' => 'Twitter',
+		'sources' => [
+			'script-src' => [
+				'platform.twitter.com',
+				'cdn.syndication.twimg.com',
+			],
+			'style-src' => [
+				'platform.twitter.com',
+				'ton.twimg.com',
+			],
+			'img-src' => [
+				'*.twimg.com',
+				'platform.twitter.com',
+				'syndication.twitter.com',
+			],
+			'frame-src' => [
+				'platform.twitter.com',
+				'syndication.twitter.com',
+			],
+		],
+	],
+	'vimeo' => [
+		'label' => 'Vimeo',
+		'sources' => [
+			'media-src' => [
+				'player.vimeo.com',
+			],
+			'frame-src' => [
+				'player.vimeo.com',
+			],
+		],
+	],
+	'wikimedia-base' => [
+		'label' => 'Wikimedia Meta, Wikimedia Commons, Wikipedia, and MediaWiki.org',
+		'sources' => [
+			'script-src' => [
+				'*.wikimedia.org',
+				'*.wikipedia.org',
+				'mediawiki.org',
+				'*.mediawiki.org',
+			],
+			'style-src' => [
+				'*.wikimedia.org',
+				'*.wikipedia.org',
+				'mediawiki.org',
+				'*.mediawiki.org',
+			],
+			'img-src' => [
+				'wikimedia.org',
+				'upload.wikimedia.org',
+				'thumb.wikimedia.org',
+			],
+			'font-src' => [
+				'upload.wikimedia.org',
+			],
+			'media-src' => [
+				'upload.wikimedia.org',
+			],
+			'connect-src' => [
+				'*.wikimedia.org',
+				'*.wikipedia.org',
+				'www.mediawiki.org',
+			],
+		],
+	],
+	'wikimedia-full' => [
+		'label' => 'Wikimedia wikis (full range of wikis)',
+		'sources' => [
+			'script-src' => [
+				'*.wikimedia.org',
+				'*.wikipedia.org',
+				'*.wikibooks.org',
+				'*.wiktionary.org',
+				'*.wikiquote.org',
+				'*.wikisource.org',
+				'*.wikiversity.org',
+				'*.wikinews.org',
+				'*.wikivoyage.org',
+				'mediawiki.org',
+				'*.mediawiki.org',
+				'wikidata.org',
+			],
+			'style-src' => [
+				'*.wikimedia.org',
+				'*.wikipedia.org',
+				'*.wikibooks.org',
+				'*.wiktionary.org',
+				'*.wikiquote.org',
+				'*.wikisource.org',
+				'*.wikiversity.org',
+				'*.wikinews.org',
+				'*.wikivoyage.org',
+				'mediawiki.org',
+				'*.mediawiki.org',
+				'wikidata.org',
+			],
+			'img-src' => [
+				'wikimedia.org',
+				'upload.wikimedia.org',
+				'thumb.wikimedia.org',
+			],
+			'font-src' => [
+				'upload.wikimedia.org',
+			],
+			'media-src' => [
+				'upload.wikimedia.org',
+			],
+			'frame-src' => [
+				'query.wikidata.org',
+			],
+			'connect-src' => [
+				'*.wikimedia.org',
+				'*.wikipedia.org',
+				'*.wikinews.org',
+				'*.wiktionary.org',
+				'www.mediawiki.org',
+				'www.wikidata.org',
+			],
+		],
+	],
+	'youtube' => [
+		'label' => 'YouTube',
+		'sources' => [
+			'script-src' => [
+				'www.youtube.com',
+			],
+			'img-src' => [
+				'i.ytimg.com',
+			],
+			'media-src' => [
+				'*.youtube.com',
+				'*.youtube-nocookie.com',
+			],
+			'frame-src' => [
+				'www.youtube.com',
+				'*.youtube-nocookie.com',
+			],
+			'connect-src' => [
+				'*.youtube-nocookie.com',
+			],
+		],
+	],
+];
+
+/**
+ * Services that an extension cannot work without.
+ */
+$wgMirahezeMagicCSPHeaderExtensionServices = [
+	'EmbedSpotify' => [
+		'spotify',
+	],
+	// We don't know which sites a wiki wants to embed videos from, so enable all of them?
+	'EmbedVideo' => [
+		'bandcamp',
+		'internet-archive',
+		'niconico',
+		'soundcloud',
+		'spotify',
+		'twitch',
+		'vimeo',
+		'youtube',
+	],
+	'GeoGebra' => [
+		'geogebra',
+	],
+	'GoogleDocs4MW' => [
+		'google',
+	],
+	'GoogleForms' => [
+		'google',
+	],
+	'Kartographer' => [
+		'openstreetmap',
+	],
+	'Maps' => [
+		'openstreetmap',
+		// Google Maps is blocked by the current CSP
+	],
+	// For image embeds. connect-src not required for the extension.
+	'RobloxAPI' => [
+		'roblox',
+	],
+	'Snap! Project Embed' => [
+		'snap',
+	],
+	'WebChat' => [
+		'libera-chat',
+	],
+];
+
+/**
+ * Services enabled by default on new wikis that never touched ManageWiki settings.
+ */
+$wgMirahezeMagicCSPEnabledServicesDefault = [
+	'cloudflare',
+	'discord',
+	'font-awesome',
+	'google-fonts',
+	'jsdelivr',
+	'wikimedia-base',
+];
+
+// Add mirabeta.org and nexttide.org to beta
 if ( $wi->isBeta() ) {
-	foreach ( $wgMirahezeMagicCSPHeaderDefault as $key => $value ) {
-		$wgMirahezeMagicCSPHeaderDefault[$key][] = '*.nexttide.org';
+	foreach ( $wgMirahezeMagicCSPHeaderEssential as $key => $value ) {
+		$wgMirahezeMagicCSPHeaderEssential[$key][] = '*.nexttide.org';
+		$wgMirahezeMagicCSPHeaderEssential[$key][] = '*.mirabeta.org';
+	}
+}
+
+// This is the old, hard-coded CSP header. Kept here for compatibility purposes.
+// It simply adds all possible services into the CSP to reobtain the full CSP.
+$wgMirahezeMagicCSPHeaderDefault = $wgMirahezeMagicCSPHeaderEssential;
+foreach ( $wgMirahezeMagicCSPServices as $service ) {
+	foreach ( $service['sources'] as $directive => $domains ) {
+		$wgMirahezeMagicCSPHeaderDefault[$directive] = array_values( array_unique(
+			array_merge( $wgMirahezeMagicCSPHeaderDefault[$directive] ?? [], $domains )
+		) );
 	}
 }
 

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -101,6 +101,9 @@ require_once '/srv/mediawiki/config/PrivateSettings.php';
 require_once '/srv/mediawiki/config/GlobalExtensions.php';
 require_once '/srv/mediawiki/config/GlobalSkins.php';
 
+// Defines variables needed in settings
+require_once '/srv/mediawiki/config/ContentSecurityPolicy.php';
+
 $wgPasswordSender = 'noreply@miraheze.org';
 $wmgUploadHostname = 'static.wikitide.net';
 
@@ -786,6 +789,11 @@ $wgConf->settings += [
 		'default' => [
 			'showcaptcha',
 		],
+	],
+
+	// Content Security Policy
+	'wgMirahezeMagicCSPEnabledServices' => [
+		'default' => $wgMirahezeMagicCSPEnabledServicesDefault,
 	],
 
 	// Contribution Scores
@@ -8036,7 +8044,6 @@ require_once '/srv/mediawiki/config/GlobalCache.php';
 require_once '/srv/mediawiki/config/GlobalLogging.php';
 require_once '/srv/mediawiki/config/Sitenotice.php';
 require_once '/srv/mediawiki/config/FileBackend.php';
-require_once '/srv/mediawiki/config/ContentSecurityPolicy.php';
 
 if ( $wgUseQuickInstantCommons ) {
 	$wgForeignFileRepos[] = [

--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -57,6 +57,9 @@
  * state: a string. Can be either 'private' or 'public'. If set to 'private' this setting will only be visible on private wikis. If set to 'public' it will only be visible on public wikis.
  */
 
+// Defines variables needed in settings
+require_once __DIR__ . '/ContentSecurityPolicy.php';
+
 $wgManageWikiSettings = [
 	// Anti-Spam
 	'wgAbuseFilterActions' => [
@@ -629,6 +632,26 @@ $wgManageWikiSettings = [
 		],
 		'help' => 'Element with these CSS classes will be removed on mobile view pages. The <code>.hidden</code> and <code>.mobile-hidden</code> classes are used on FANDOM, and may be enabled for compatibility with FANDOM imports.',
 		'requires' => [],
+	],
+	'wgMirahezeMagicCSPEnabledServices' => [
+		'name' => 'Content Security Policy services',
+		'from' => 'mediawiki',
+		'global' => true,
+		'type' => 'list-multi',
+		'overridedefault' => $wgMirahezeMagicCSPEnabledServicesDefault,
+		'section' => 'other',
+		'options' => array_combine(
+			array_column( $wgMirahezeMagicCSPServices, 'label' ),
+			array_keys( $wgMirahezeMagicCSPServices )
+		),
+		'help' => 'Third party services that pages on this wiki are allowed to load content from. Sites selected here will be added to the CSP. See [[m:Help:Content_Security_Policy|Help:Content Security Policy]] for details.',
+		// Restricted for now since it doesn't actually do anything and we don't want to
+		// confuse users.
+		'requires' => [
+			'permissions' => [
+				'managewiki-restricted',
+			],
+		],
 	],
 
 	// Beta Feature related stuff

--- a/tests/ManageWiki/SettingsTest.php
+++ b/tests/ManageWiki/SettingsTest.php
@@ -267,7 +267,8 @@ class SettingsTest extends ManageWikiTestCase {
 
 	/** @covers $wgManageWikiSettings */
 	public function testManageWikiSettings() {
-		global $wgManageWikiSettings, $wgPasswordSender, $wmgSharedUploadDBname, $wmgUploadHostname, $wi;
+		global $wgManageWikiSettings, $wgDBname, $wgPasswordSender, $wmgSharedUploadDBname, $wmgUploadHostname, $wi;
+		$wgDBname = '';
 		$wgPasswordSender = '';
 		$wmgSharedUploadDBname = '';
 		$wmgUploadHostname = '';

--- a/tests/Mock/MirahezeFunctions.php
+++ b/tests/Mock/MirahezeFunctions.php
@@ -13,6 +13,10 @@ class MirahezeFunctions {
 		return [];
 	}
 
+	public function isBeta(): bool {
+		return false;
+	}
+
 	public function isAllOfExtensionsActive(): true {
 		return true;
 	}


### PR DESCRIPTION
Backward-compatible patch will adds a ManageWiki setting to selectively add services to the CSP.

Each service corresponds to one or more CSP directives. It's either all or nothing. For finer granularity some services are split into two, such as `wikimedia-base` and `wikimedia-full`.